### PR TITLE
Move Arith constraints to Agent.instances 

### DIFF
--- a/src/main/scala/symsim/Agent.scala
+++ b/src/main/scala/symsim/Agent.scala
@@ -54,7 +54,7 @@ trait Agent[State, FiniteState, Action, Reward, Scheduler[_]] {
   /** Type evidence required to consider a generic instance of Agent to be
     * an agent for the rest of the framework
     */
-  val instances: AgentConstraints[State, FiniteState, Action, Scheduler]
+  val instances: AgentConstraints[State, FiniteState, Action, Reward, Scheduler]
 
 }
 
@@ -62,7 +62,7 @@ trait Agent[State, FiniteState, Action, Reward, Scheduler[_]] {
 /** Type evidence required to consider a generic instance of Agent to be
   * an agent for the rest of the framework
   */
-trait AgentConstraints[State, FiniteState, Action, Scheduler[_]] {
+trait AgentConstraints[State, FiniteState, Action, Reward, Scheduler[_]] {
 
   import org.scalacheck.Arbitrary
   import cats.kernel.BoundedEnumerable
@@ -90,5 +90,8 @@ trait AgentConstraints[State, FiniteState, Action, Scheduler[_]] {
 
   /** We can generate random actions for testing */
   implicit def arbitraryAction: Arbitrary[Action]
+
+  /** Reward is an arithmetic type according to Arith */
+  implicit def rewardArith: Arith[Reward]
 
 }

--- a/src/main/scala/symsim/examples/concrete/breaking/Car.scala
+++ b/src/main/scala/symsim/examples/concrete/breaking/Car.scala
@@ -54,7 +54,7 @@ object Car
   * needs to be able to do to work in the framework.
   */
 object CarInstances
-  extends AgentConstraints[CarState, CarFiniteState, CarAction, Randomized] {
+  extends AgentConstraints[CarState, CarFiniteState, CarAction, CarReward, Randomized] {
 
   import cats.{Eq, Monad}
   import cats.kernel.BoundedEnumerable
@@ -93,4 +93,7 @@ object CarInstances
 
   implicit lazy val arbitraryAction =
     Arbitrary (Gen.double)
+
+  implicit lazy val rewardArith: Arith[CarReward] =
+    Arith.arithDouble
 }

--- a/src/main/scala/symsim/laws/SarsaLaws.scala
+++ b/src/main/scala/symsim/laws/SarsaLaws.scala
@@ -19,7 +19,7 @@ import cats.kernel.BoundedEnumerable
  *
  * Same comment in AgentLaws.scala
  */
-class SarsaLaws[State,FiniteState, Action, Reward: Arith, Scheduler[_]] (
+class SarsaLaws[State,FiniteState, Action, Reward, Scheduler[_]] (
   val s: Sarsa[State, FiniteState, Action, Reward, Scheduler]
 ) {
 

--- a/src/main/scala/symsim/laws/discipline/SarsaTests.scala
+++ b/src/main/scala/symsim/laws/discipline/SarsaTests.scala
@@ -6,32 +6,22 @@ import cats.laws.discipline._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll
 
-trait SarsaTests[State, FiniteState, Action, Reward, Scheduler[_]]
-  extends org.typelevel.discipline.Laws {
+class SarsaTests[State, FiniteState, Action, Reward, Scheduler[_]]
+  (s: Sarsa[State, FiniteState, Action, Reward, Scheduler])
+    extends org.typelevel.discipline.Laws
+{
 
-  implicit def evReward: Arith[Reward]
+  type S = Sarsa[State, FiniteState, Action, Reward, Scheduler]
 
-  def laws (s: Sarsa[State, FiniteState, Action, Reward, Scheduler]) =
-    new symsim.laws.SarsaLaws (s)
+  val laws = new symsim.laws.SarsaLaws (s)
 
-  def sarsa (s: Sarsa[State, FiniteState, Action, Reward, Scheduler])
-    (implicit arbUnit: Arbitrary[Unit], eqUnit: Eq[Unit]): RuleSet =
-    new SimpleRuleSet (
+  def sarsa: RuleSet = new SimpleRuleSet (
       "sarsa",
       // TODO: deactivated tentatively
       // "initQ produces a zero matrix of the right size" ->
-      //   laws (s).initQRightSize,
+      //   laws.initQRightSize,
       // TODO: remove this one soon
       "sanity always passes law" ->
-        forAll (laws (s).alwaysPassesSanity _)
+        forAll (laws.alwaysPassesSanity _)
     )
-}
-
-object SarsaTests {
-
-  def apply[State, FiniteState, Action, Reward: Arith, Scheduler[_]]
-  : SarsaTests[State, FiniteState, Action, Reward, Scheduler] =
-    new SarsaTests[State, FiniteState, Action, Reward, Scheduler] {
-      override def evReward = implicitly[Arith[Reward]]
-    }
 }

--- a/src/test/scala/symsim/concrete/ConcreteSarsaIsSarsaSpec.scala
+++ b/src/test/scala/symsim/concrete/ConcreteSarsaIsSarsaSpec.scala
@@ -6,7 +6,6 @@ import _root_.symsim.laws.discipline.SarsaTests
 
 class ConcreteSarsaIsSarsaSpec extends SymSimSpec {
 
-    // TODO: This would be nice to pbt
     val csarsa = ConcreteSarsa[
       CarState,
       CarFiniteState,
@@ -21,6 +20,6 @@ class ConcreteSarsaIsSarsaSpec extends SymSimSpec {
     )
 
   checkAll ("concrete.ConcreteSarsa is Sarsa",
-    SarsaTests[CarState, CarFiniteState, CarAction, CarReward, Randomized].sarsa (csarsa) )
+    new SarsaTests[CarState, CarFiniteState, CarAction, CarReward, Randomized] (csarsa).sarsa )
 
 }


### PR DESCRIPTION
This reduces pollution on all sorts of methods with individual constraints.  We might regret that later, if it turns out that we will have to create weird agents that satisfy needless constraints later, but for now it seems that all constraints are met in the agent, so perhaps we should just stick to hold everything there.  It might be even beneficial to encapsulate all interface types inside, then we will not have to carry so many types around.