### PR TITLE
Support randomized simulators, with Maze in view

### DIFF
--- a/src/main/scala/symsim/Sarsa.scala
+++ b/src/main/scala/symsim/Sarsa.scala
@@ -44,23 +44,20 @@ trait Sarsa[State, FiniteState, Action, Reward, Scheduler[_]]
     * reward difference (the size of the update performed)
     */
   def learn1 (q: Q, s_t: State): Scheduler[(Q,State)] = for
-
     a_t <- chooseAction (q) (s_t)
     sa_tt <- agent.step (s_t) (a_t)
     (s_tt, r_tt) = sa_tt
     a_tt = bestAction (q) (s_tt)
 
-    // concerned that this is Q-learning not SARSA (p.844 in Russel & Norvig)
+    // this is Q-learning not SARSA (p.844 in Russel & Norvig)
     ds_t = agent.discretize (s_t)
     ds_tt = agent.discretize (s_tt)
     old_entry = q (ds_t) (a_t)
-    correction = r_tt + gamma * (q (ds_tt) (a_tt)) - old_entry
+    correction = r_tt + gamma * q (ds_tt) (a_tt) - old_entry
     qval = old_entry + alpha * correction
 
     q1 = q + (ds_t -> (q (ds_t) + (a_t -> qval)))
-
   yield (q1, s_tt)
-
 
 
   /** Execute a full learning episode (until the final state of agent is

--- a/src/main/scala/symsim/Sarsa.scala
+++ b/src/main/scala/symsim/Sarsa.scala
@@ -46,9 +46,8 @@ trait Sarsa[State, FiniteState, Action, Reward, Scheduler[_]]
   def learn1 (q: Q, s_t: State): Scheduler[(Q,State)] = for
 
     a_t <- chooseAction (q) (s_t)
-
-    (s_tt, r_tt) = agent.step (s_t) (a_t)
-
+    sa_tt <- agent.step (s_t) (a_t)
+    (s_tt, r_tt) = sa_tt
     a_tt = bestAction (q) (s_tt)
 
     // concerned that this is Q-learning not SARSA (p.844 in Russel & Norvig)

--- a/src/main/scala/symsim/concrete/ConcreteSarsa.scala
+++ b/src/main/scala/symsim/concrete/ConcreteSarsa.scala
@@ -12,7 +12,7 @@ case class ConcreteSarsa [
   val agent: Agent[State, FiniteState, Action, Double, Randomized],
   val alpha: Double,
   val gamma: Double,
-  val distraction: Probability,
+  val epsilon: Probability,
   val epochs: Int,
   val seed: Long
 
@@ -20,23 +20,21 @@ case class ConcreteSarsa [
 
   import agent.instances.given
 
-  // TODO: it is a bit unclear if this is general (if it turns out to be the
+  // TODO: unclear if this is general (if it turns out to be the
   // same im symbolic SARSA we should promote this to the trait
 
   def bestAction (q: Q) (s: State): Action =
     val qs = q (agent.discretize (s)) map { _.swap }
-    val M = qs.keys.max
-    qs (M)
+    qs (qs.keys.max)
 
 
-
-  /** Action selection policy based on argMax and randomzation.  */
+  /** Action selection policy based on argMax and randomization.  */
   def chooseAction (q: Q) (s: State): Randomized[Action] =
     for
-      distracted <- Randomized.coin (distraction)
+      distracted <- Randomized.coin (epsilon)
       action <- if distracted
-                then Randomized.oneOf (agent.instances.enumAction.membersAscending)
-                else Randomized.const (bestAction (q) (s))
+        then Randomized.oneOf (agent.instances.enumAction.membersAscending: _*)
+        else Randomized.const (bestAction (q) (s))
     yield action
 
 

--- a/src/main/scala/symsim/concrete/ConcreteSarsa.scala
+++ b/src/main/scala/symsim/concrete/ConcreteSarsa.scala
@@ -18,7 +18,7 @@ case class ConcreteSarsa [
 
 ) extends Sarsa[State, FiniteState, Action, Double, Randomized]:
 
-  import agent.instances.given
+  import agent.instances._
 
   // TODO: unclear if this is general (if it turns out to be the
   // same im symbolic SARSA we should promote this to the trait
@@ -31,9 +31,9 @@ case class ConcreteSarsa [
   /** Action selection policy based on argMax and randomization.  */
   def chooseAction (q: Q) (s: State): Randomized[Action] =
     for
-      distracted <- Randomized.coin (epsilon)
-      action <- if distracted
-        then Randomized.oneOf (agent.instances.enumAction.membersAscending: _*)
+      explore <- Randomized.coin (this.epsilon)
+      action <- if explore
+        then Randomized.oneOf (allActions: _*)
         else Randomized.const (bestAction (q) (s))
     yield action
 
@@ -42,13 +42,11 @@ case class ConcreteSarsa [
   /** Construct a zero initialized Q matrix */
   def initQ: Q =
     // Create the initial Q matrix (zero's everywhere)
-    val qa = BoundedEnumerable[Action]
-      .membersAscending
+    val qa = allActions
       .map { a => (a, agent.zeroReward) }
       .toMap
 
-    val q0 = BoundedEnumerable[FiniteState]
-      .membersAscending
+    val q0 = allFiniteStates
       .map { state => (state, qa) }
       .toMap
 

--- a/src/main/scala/symsim/concrete/Randomized.scala
+++ b/src/main/scala/symsim/concrete/Randomized.scala
@@ -32,11 +32,12 @@ object Randomized:
     State { r => (r, r.between (minInclusive, maxExclusive)) }
 
 
+  /** Toss a coing biased towards true with probabilty 'bias' */
   def coin (bias: Probability): Randomized[Boolean] =
     for toss <- prob yield toss <= bias
 
 
-  def oneOf[A] (choices: Seq[A]): Randomized[A] =
+  def oneOf[A] (choices: A*): Randomized[A] =
     for i <- between (0, choices.size) yield choices (i)
 
 

--- a/src/main/scala/symsim/examples/concrete/breaking/Car.scala
+++ b/src/main/scala/symsim/examples/concrete/breaking/Car.scala
@@ -46,16 +46,14 @@ object Car
     /** Granularity of the step in seconds */
     private val t: Double = 2.0
 
-
     // TODO: this is now deterministic but eventually needs to be randomized
-    def step (s: CarState) (a: CarAction): (CarState, CarReward) =
+    def step (s: CarState) (a: CarAction): Randomized[(CarState, CarReward)] =
       // Stop moving when velecity is zero, breaking is not moving backwards
       val t1 = Math.min (- s.v / a, t)
-
       val p1 = Math.min (s.p + s.v*t1 + 0.5*a*t1*t1, 10.0)
       val v1 = Math.max (s.v + a*t1, 0.0)
       val s1 = CarState (p1, v1)
-      s1 -> carReward (s1) (a)
+      Randomized.const (s1 -> carReward (s1) (a))
 
 
     def initialize: Randomized[CarState] = for

--- a/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
+++ b/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
@@ -20,7 +20,7 @@ import symsim.concrete.Randomized
  */
 
 case class MazeState (x: Int, y: Int):
-  override def toString: String = s"[x=$x, y=$y]"
+   override def toString: String = s"[x=$x, y=$y]"
 
 type MazeFiniteState = MazeState
 type MazeReward = Double
@@ -33,53 +33,52 @@ case object Down extends MazeAction
 
 
 object Maze
-  extends Agent[MazeState, MazeFiniteState, MazeAction, MazeReward, Randomized]:
+   extends Agent[MazeState, MazeFiniteState, MazeAction, MazeReward, Randomized]:
 
-    def isFinal (s: MazeState): Boolean =
-      s == MazeState (4, 3) || s == MazeState (4, 2)
+      def isFinal (s: MazeState): Boolean =
+         s == MazeState (4, 3) || s == MazeState (4, 2)
 
-    // Maze is discrete
-    def discretize (s: MazeState): MazeFiniteState =  s
+      // Maze is discrete
+      def discretize (s: MazeState): MazeFiniteState =  s
 
-    private def mazeReward (s: MazeState): MazeReward = s match {
-      case MazeState (4, 3) => 10.0   // Good final state
-      case MazeState (4, 2) => -10.0  // Bad final state
-      case MazeState (_, _) => -1.0
-    }
-
-
-    def distort (a: MazeAction): Randomized[MazeAction] = a match
-      case Up | Down => Randomized.oneOf (Left, Right)
-      case Left | Right => Randomized.oneOf (Up, Down)
+      private def mazeReward (s: MazeState): MazeReward = s match
+        case MazeState (4, 3) => 10.0   // Good final state
+        case MazeState (4, 2) => -10.0  // Bad final state
+        case MazeState (_, _) => -1.0
 
 
-    def successor (s: MazeState) (a: MazeAction): MazeState =
-      require (valid (s))
-      val result = a match
-        case Up => s.copy (y = s.y+1)
-        case Down => s.copy (y = s.y-1)
-        case Left => s.copy (x = s.x-1)
-        case Right => s.copy (x = s.x+1)
-      if valid (result) then result else s
+      def distort (a: MazeAction): Randomized[MazeAction] = a match
+         case Up | Down => Randomized.oneOf (Left, Right)
+         case Left | Right => Randomized.oneOf (Up, Down)
 
-    def valid (s: MazeState): Boolean =
-      s.x >= 1 && s.x <= 4 && s.y >= 1 && s.y <= 3 && s != MazeState (2, 2)
 
-    val attention = 0.8
+      def successor (s: MazeState) (a: MazeAction): MazeState =
+         require (valid (s))
+         val result = a match
+            case Up => s.copy (y = s.y+1)
+            case Down => s.copy (y = s.y-1)
+            case Left => s.copy (x = s.x-1)
+            case Right => s.copy (x = s.x+1)
+         if valid (result) then result else s
 
-    def step (s: MazeState) (a: MazeAction): Randomized[(MazeState, MazeReward)] =
-      for
-        precise <- Randomized.coin (attention)
-        action <- if precise then Randomized.const (a) else distort (a)
-        newState = successor (s) (action)
-      yield (newState, mazeReward (newState))
+      def valid (s: MazeState): Boolean =
+         s.x >= 1 && s.x <= 4 && s.y >= 1 && s.y <= 3 && s != MazeState (2, 2)
 
-    def initialize: Randomized[MazeState] =
-      Randomized.oneOf (instances.allFiniteStates.filter { s => !isFinal (s) }:_*)
+      val attention = 0.8
 
-    override def zeroReward: MazeReward = 0
+      def step (s: MazeState) (a: MazeAction): Randomized[(MazeState, MazeReward)] =
+         for
+            precise <- Randomized.coin (attention)
+            action <- if precise then Randomized.const (a) else distort (a)
+            newState = successor (s) (action)
+         yield (newState, mazeReward (newState))
 
-    val instances = MazeInstances
+      def initialize: Randomized[MazeState] =
+         Randomized.oneOf (instances.allFiniteStates.filter { s => !isFinal (s) }:_*)
+
+      override def zeroReward: MazeReward = 0
+
+      val instances = MazeInstances
 
 
 
@@ -87,36 +86,36 @@ object Maze
   * needs to be able to do to work in the framework.
   */
 object MazeInstances
-  extends AgentConstraints[MazeState, MazeFiniteState, MazeAction, MazeReward, Randomized]:
+   extends AgentConstraints[MazeState, MazeFiniteState, MazeAction, MazeReward, Randomized]:
 
-  given enumAction: BoundedEnumerable[MazeAction] =
-    BoundedEnumerableFromList (Up, Down, Left, Right)
+   given enumAction: BoundedEnumerable[MazeAction] =
+      BoundedEnumerableFromList (Up, Down, Left, Right)
 
-  given enumState: BoundedEnumerable[MazeFiniteState] =
-    val ss = for
-      y <- List (1, 2, 3)
-      x <- List (1, 2, 3, 4)
-      result = MazeState (x, y)
-      if Maze.valid (result)
-    yield result
-    BoundedEnumerableFromList (ss: _*)
+   given enumState: BoundedEnumerable[MazeFiniteState] =
+      val ss = for
+         y <- List (1, 2, 3)
+         x <- List (1, 2, 3, 4)
+         result = MazeState (x, y)
+         if Maze.valid (result)
+      yield result
+      BoundedEnumerableFromList (ss: _*)
 
-  given schedulerIsMonad: Monad[Randomized] =
-    concrete.Randomized.randomizedIsMonad
+   given schedulerIsMonad: Monad[Randomized] =
+      concrete.Randomized.randomizedIsMonad
 
-  given canTestInScheduler: CanTestIn[Randomized] =
-    concrete.Randomized.canTestInRandomized
+   given canTestInScheduler: CanTestIn[Randomized] =
+      concrete.Randomized.canTestInRandomized
 
-  lazy val genMazeState: Gen[MazeState] = for
-    y <- Gen.choose (1,3)
-    x <- Gen.choose (1,4)
-    if (x != 2 && y != 2)
-  yield MazeState (x = x.abs, y = y.abs)
+   lazy val genMazeState: Gen[MazeState] = for
+      y <- Gen.choose (1,3)
+      x <- Gen.choose (1,4)
+      if (x != 2 && y != 2)
+   yield MazeState (x = x.abs, y = y.abs)
 
-  given arbitraryState: Arbitrary[MazeState] = Arbitrary (genMazeState)
+   given arbitraryState: Arbitrary[MazeState] = Arbitrary (genMazeState)
 
-  given eqMazeState: Eq[MazeState] = Eq.fromUniversalEquals
+   given eqMazeState: Eq[MazeState] = Eq.fromUniversalEquals
 
-  given arbitraryReward: Arbitrary[MazeReward] = Arbitrary (Gen.double)
+   given arbitraryReward: Arbitrary[MazeReward] = Arbitrary (Gen.double)
 
-  given rewardArith: Arith[MazeReward] = Arith.given_Arith_Double
+   given rewardArith: Arith[MazeReward] = Arith.given_Arith_Double

--- a/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
+++ b/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
@@ -41,24 +41,29 @@ object Maze
     // Maze is discrete
     def discretize (s: MazeState): MazeFiniteState =  s
 
-    private def mazeReward (s: MazeState): MazeReward =
-      if s == MazeState (x=4, y=3) then 10        //Good final state
-      else if s == MazeState (x=4, y=2) then -10  // Bad final state
-      else -1
+    private def mazeReward (s: MazeState): MazeReward = s match {
+      case MazeState (4, 3) => 10.0   // Good final state
+      case MazeState (4, 2) => -10.0  // Bad final state
+      case MazeState (_, _) => -1.0
+    }
 
-    def successor (s: MazeState) (a: MazeAction) = a match
-      case Up => s.copy (y = s.y+1)
-      case Down => s.copy (y = s.y-1)
-      case Left => s.copy (x = s.x-1)
-      case Right => s.copy (x = s.x+1)
-
-
-    def valid (s: MazeState): Boolean =
-      s.x >= 1 && s.x <= 4 && s.y >= 1 && s.y <= 3 && s != MazeState (2, 2)
 
     def distort (a: MazeAction): Randomized[MazeAction] = a match
       case Up | Down => Randomized.oneOf (Left, Right)
       case Left | Right => Randomized.oneOf (Up, Down)
+
+
+    def successor (s: MazeState) (a: MazeAction): MazeState =
+      require (valid (s))
+      val result = a match
+        case Up => s.copy (y = s.y+1)
+        case Down => s.copy (y = s.y-1)
+        case Left => s.copy (x = s.x-1)
+        case Right => s.copy (x = s.x+1)
+      if valid (result) then result else s
+
+    def valid (s: MazeState): Boolean =
+      s.x >= 1 && s.x <= 4 && s.y >= 1 && s.y <= 3 && s != MazeState (2, 2)
 
     val attention = 0.8
 
@@ -67,13 +72,10 @@ object Maze
         precise <- Randomized.coin (attention)
         action <- if precise then Randomized.const (a) else distort (a)
         newState = successor (s) (action)
-        result = if valid (newState)
-          then newState -> mazeReward (newState)
-          else s -> mazeReward (s)
-      yield result
+      yield (newState, mazeReward (newState))
 
     def initialize: Randomized[MazeState] =
-      Randomized.oneOf (instances.allFiniteStates.filter {s => !isFinal (s) }: _*)
+      Randomized.oneOf (instances.allFiniteStates.filter { s => !isFinal (s) }:_*)
 
     override def zeroReward: MazeReward = 0
 
@@ -92,10 +94,11 @@ object MazeInstances
 
   given enumState: BoundedEnumerable[MazeFiniteState] =
     val ss = for
-        y <- Seq (1, 2, 3)
-        x <- Seq (1, 2, 3, 4)
-        if (x,y) != (2,2)
-    yield MazeState (x, y)
+      y <- List (1, 2, 3)
+      x <- List (1, 2, 3, 4)
+      result = MazeState (x, y)
+      if Maze.valid (result)
+    yield result
     BoundedEnumerableFromList (ss: _*)
 
   given schedulerIsMonad: Monad[Randomized] =

--- a/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
+++ b/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
@@ -35,52 +35,45 @@ case object Down extends MazeAction
 object Maze
   extends Agent[MazeState, MazeFiniteState, MazeAction, MazeReward, Randomized]:
 
-    def isFinal (s: MazeState): Boolean = s.x == 4 && (s.y == 2 || s.y == 3)
+    def isFinal (s: MazeState): Boolean =
+      s == MazeState (4, 3) || s == MazeState (4, 2)
 
     // Maze is discrete
     def discretize (s: MazeState): MazeFiniteState =  s
 
     private def mazeReward (s: MazeState): MazeReward =
-      if s == MazeState(x=4,y=3) then 10          //Good final state
-      else if (s == MazeState(x=4,y=2)) then -10  // Bad final state
+      if s == MazeState (x=4, y=3) then 10        //Good final state
+      else if s == MazeState (x=4, y=2) then -10  // Bad final state
       else -1
 
-    // TODO: this is now deterministic but eventually needs to be randomized
-    def step (s: MazeState) (a: MazeAction): (MazeState, MazeReward) =
-      val newstate = a match {
-        case Up =>    stepUp(s)
-        case Down =>  stepDown(s)
-        case Left =>  stepLeft(s)
-        case Right => stepRight(s)
-      }
-      if isValid (newstate)
-      then (newstate, mazeReward(newstate))
-      else (s, mazeReward(s))
+    def successor (s: MazeState) (a: MazeAction) = a match
+      case Up => s.copy (y = s.y+1)
+      case Down => s.copy (y = s.y-1)
+      case Left => s.copy (x = s.x-1)
+      case Right => s.copy (x = s.x+1)
 
 
-    def  isValid (s: MazeState) =
-      s.x >= 1 && s.x <=4 && s.y >= 1 && s.y <= 3 && (s != MazeState (2,2))
+    def valid (s: MazeState): Boolean =
+      s.x >= 1 && s.x <= 4 && s.y >= 1 && s.y <= 3 && s != MazeState (2, 2)
 
-    def stepUp(s: MazeState): MazeState = MazeState(x=s.x,y=s.y+1)
+    def distort (a: MazeAction): Randomized[MazeAction] = a match
+      case Up | Down => Randomized.oneOf (Left, Right)
+      case Left | Right => Randomized.oneOf (Up, Down)
 
+    val attention = 0.8
 
-    def stepDown(s: MazeState): MazeState = MazeState(x=s.x,y=s.y-1)
+    def step (s: MazeState) (a: MazeAction): Randomized[(MazeState, MazeReward)] =
+      for
+        precise <- Randomized.coin (attention)
+        action <- if precise then Randomized.const (a) else distort (a)
+        newState = successor (s) (action)
+        result = if valid (newState)
+          then newState -> mazeReward (newState)
+          else s -> mazeReward (s)
+      yield result
 
-
-    def stepLeft(s: MazeState): MazeState = MazeState(x=s.x-1,y=s.y)
-
-
-    def stepRight(s: MazeState): MazeState = MazeState(x=s.x+1,y=s.y)
-
-
-    def initialize: Randomized[MazeState] = for
-      y <- Randomized.between (1, 3)
-      x <- Randomized.between (1, 4)
-      s0 = MazeState (x,y)
-      s <- if isFinal (s0) || s0 == MazeState(2,2)
-           then initialize
-           else Randomized.const (s0)
-    yield s
+    def initialize: Randomized[MazeState] =
+      Randomized.oneOf (instances.allFiniteStates.filter {s => !isFinal (s) }: _*)
 
     override def zeroReward: MazeReward = 0
 
@@ -99,9 +92,10 @@ object MazeInstances
 
   given enumState: BoundedEnumerable[MazeFiniteState] =
     val ss = for
-      y <- Seq (1, 2, 3)
-      x <- Seq (1, 2, 3, 4)
-    yield MazeState (x,y)
+        y <- Seq (1, 2, 3)
+        x <- Seq (1, 2, 3, 4)
+        if (x,y) != (2,2)
+    yield MazeState (x, y)
     BoundedEnumerableFromList (ss: _*)
 
   given schedulerIsMonad: Monad[Randomized] =
@@ -112,8 +106,9 @@ object MazeInstances
 
   lazy val genMazeState: Gen[MazeState] = for
     y <- Gen.choose (1,3)
-    x <- Gen.choose (1,4) if (x != 2 && y != 2)
-  yield MazeState (y=Math.abs (y), x=Math.abs (x))
+    x <- Gen.choose (1,4)
+    if (x != 2 && y != 2)
+  yield MazeState (x = x.abs, y = y.abs)
 
   given arbitraryState: Arbitrary[MazeState] = Arbitrary (genMazeState)
 

--- a/src/main/scala/symsim/laws/AgentLaws.scala
+++ b/src/main/scala/symsim/laws/AgentLaws.scala
@@ -59,7 +59,10 @@ class AgentLaws[State, FiniteState, Action, Reward, Scheduler[_] ]
   def stepIsIntoFiniteState: Prop =
     forAll { (s0: State) =>
       forAll { (a: Action) =>
-        val (s1, r) = agent.step (s0) (a)
-        val d1 = agent.discretize (s1)
-        finiteStates.contains (d1)
-    } }
+        (for
+            s1r <- agent.step (s0) (a)
+            (s1,r) = s1r
+            d1 = agent.discretize (s1)
+        yield finiteStates contains d1).toProp
+      }
+    }

--- a/src/main/scala/symsim/laws/AgentLaws.scala
+++ b/src/main/scala/symsim/laws/AgentLaws.scala
@@ -42,15 +42,13 @@ class AgentLaws[State, FiniteState, Action, Reward, Scheduler[_] ]
     * of FiniteState.
     */
   def initializeIsIntoFiniteState: Prop =
-    val ini = agent.initialize
-    forAll (ini.toGen) { (s: State) =>
+    forAll (agent.initialize.toGen) { (s: State) =>
       finiteStates.contains (agent.discretize (s)) }
 
 
   /** Law: Initial state is not final, regardless scheduler. */
   def initialStateIsNotFinal: Prop =
-    val ini = agent.initialize
-    forAll (ini.toGen) { (s: State) => ! agent.isFinal (s) }
+    forAll (agent.initialize.toGen) { (s: State) => ! agent.isFinal (s) }
 
 
   /** Law: An agent step from any state lands in a state that be discretized

--- a/src/main/scala/symsim/laws/SarsaLaws.scala
+++ b/src/main/scala/symsim/laws/SarsaLaws.scala
@@ -57,6 +57,8 @@ class SarsaLaws[State,FiniteState, Action, Reward, Scheduler[_]] (
 
   // TODO  "this is for RL: eventually we arrive at final (episodic agent)" ->
   //      Prop.falsified,
+  //
+  // TODO the utility of all actions in the terminal state should be zero
 
   /** Law: Q matrix has a action-reward map for each finite state */
   def initQDefinedForAllFiniteStates: Prop = isStateTotal (sarsa.initQ)

--- a/src/test/scala/symsim/concrete/ConcreteSarsaIsSarsaSpec.scala
+++ b/src/test/scala/symsim/concrete/ConcreteSarsaIsSarsaSpec.scala
@@ -13,8 +13,8 @@ class ConcreteSarsaIsSarsaSpec extends SymSimSpec:
   ] (
     agent = MountainCar,
     alpha = 0.1,
-    gamma = 0.1,
-    distraction = 0.05,
+    gamma = 1.0,
+    epsilon = 0.05,
     epochs = 5000,
     seed = 1000
   )

--- a/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
@@ -23,7 +23,7 @@ class Experiments
       agent = Car,
       alpha = 0.1,
       gamma = 0.1,
-      distraction = 0.05, // explore vs exploit ratio
+      epsilon = 0.05, // explore vs exploit ratio
       epochs = 5000,
       seed = 1000
     )

--- a/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
@@ -22,7 +22,7 @@ class Experiments
       agent = MountainCar,
       alpha = 0.1,
       gamma = 0.1,
-      distraction = 0.05, // explore vs exploit ration.
+      epsilon = 0.05, // explore vs exploit ration.
       epochs = 5000,
       seed = 1000
     )

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -21,9 +21,9 @@ class Experiments
       MazeAction
     ] (
       agent = Maze,
-      alpha = 0.1,
+      alpha = 1.0,
       gamma = 1.0,
-      distraction = 0.05, // explore vs exploit ratio
+      epsilon = 0.05, // explore vs exploit ratio
       epochs = 100000,
       seed = 1000
     )

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -12,18 +12,15 @@ class Experiments
 
   "test run" in {
 
-    // Import evidence that states and actions can be enumerated
-    import Maze._
-
     val sarsa = ConcreteSarsa[
       MazeState,
       MazeFiniteState,
       MazeAction
     ] (
       agent = Maze,
-      alpha = 1.0,
+      alpha = 0.2,
       gamma = 1.0,
-      epsilon = 0.05, // explore vs exploit ratio
+      epsilon = 0.0, // explore vs exploit ratio
       epochs = 100000,
       seed = 1000
     )


### PR DESCRIPTION
I added randomized simulation to Agents, Sarsa, and Concrete Sarsa, and updated all the agents.  Please have a look whether changes (under Files) make sense for you, and please check the performance of the learning on the maze example.  If you say that this is fine, I will merge.