### PR TITLE
Replace java.util.Random with SecureRandom

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -9,13 +9,21 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11.0.11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'adopt' # See 'Supported distributions' for available options
         java-version: 11.0.11
+    - name: Install sbt
+      run: |
+       apt-get update && apt-get install -y gnupg2 curl
+       echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list
+       curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
+       apt-get update && apt-get install -y sbt
     - name: Run tests
-      run: sbt test
+      run: |
+       export SBT_OPTS="-Xmx3G -XX:+UseG1GC -Xss2M" && sbt test

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -20,10 +20,12 @@ jobs:
         java-version: 11.0.11
     - name: Install sbt
       run: |
-       apt-get update && apt-get install -y gnupg2 curl
-       echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list
-       curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
-       apt-get update && apt-get install -y sbt
+       sudo apt-get update 
+       sudo apt-get install -y gnupg2 curl
+       echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+       curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+       sudo apt-get update 
+       sudo apt-get install -y sbt
     - name: Run tests
       run: |
        export SBT_OPTS="-Xmx3G -XX:+UseG1GC -Xss2M" && sbt test

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The implementation is quite memory hungry right now, so we recommend
 the following sbt setup to increase the available heap:
 
    ```sh
-   export SBT_OPTS="-Xmx2G -XX:+UseG1GC -Xss2M"
+   export SBT_OPTS="-Xmx3G -XX:+UseG1GC -Xss2M"
    ```
 Place this in your `.bashrc` or execute in the current shell, just
 before starting `sbt`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 ![Scala CI](https://github.com/itu-square/symsim/workflows/Scala%20CI/badge.svg)
 
+## Requirements
+
+The implementation is quite memory hungry right now, so we recommend
+the following sbt setup to increase the available heap:
+
+   ```sh
+   export SBT_OPTS="-Xmx2G -XX:+UseG1GC -Xss2M"
+   ```
+Place this in your `.bashrc` or execute in the current shell, just
+before starting `sbt`.
+
 ## Add a new agent (A new example)
 
 1. `Git clone` the repo or `git pull` to have the fresh version
@@ -9,7 +20,7 @@
    git checkout -b tic-tac-toe
    ```
 3. Create a new package in `src/main/scala/symsim/examples/concrete/`. The existing one is called `breaking`, let's call the new one `tictactoe`
-   
+
    ```sh
    mkdir -pv src/main/scala/symsim/examples/concrete/tictactoe
    ```
@@ -24,7 +35,7 @@
    `TicState` - to represent the state of the game
    `TicFiniteState` - this might be just a renaming because the Tic Tac Toe state space is finite
    `TicAction` - possible moves
-   
+
 5. Create the file with the implementation of the TicTacToe Agent.  You might want to copy:
    ```
    cp -iv src/main/scala/symsim/examples/concrete/breaking/Car.scala src/main/scala/symsim/examples/concrete/tictactoe/Tic.scala
@@ -41,4 +52,4 @@
    ...>compile
    ```
 
-9. TODO: describe how to run and test it 
+9. TODO: describe how to run and test it

--- a/build.sbt
+++ b/build.sbt
@@ -25,5 +25,6 @@ libraryDependencies ++= Seq (
   "org.typelevel" %% "paiges-core" % "0.4.1"
 )
 
+Test / parallelExecution := false
 Test / testOptions += Tests.Argument("-oD")
 // Test / testOptions += Tests.Argument (TestFrameworks.ScalaTest, "-h", "target/report")

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ val catsVersion = "2.5.0"
 scalacOptions ++= Seq (
   "-deprecation",
   "-feature",
-  "-explain-types",
   "-Xfatal-warnings",
 )
 

--- a/src/main/scala/symsim/concrete/ConcreteSarsa.scala
+++ b/src/main/scala/symsim/concrete/ConcreteSarsa.scala
@@ -14,7 +14,6 @@ case class ConcreteSarsa [
   val gamma: Double,
   val epsilon: Probability,
   val epochs: Int,
-  val seed: Long
 
 ) extends Sarsa[State, FiniteState, Action, Double, Randomized]:
 

--- a/src/main/scala/symsim/concrete/ConcreteSarsa.scala
+++ b/src/main/scala/symsim/concrete/ConcreteSarsa.scala
@@ -54,11 +54,6 @@ case class ConcreteSarsa [
 
 
 
-  def runQ: Q =
-    learnN (epochs, initQ)
-      // Got a Randomized[QS], run it from the seed
-      .runA (new scala.util.Random (seed))
-      // Get the value out of run (which returns an Eval)
-      .value
+  def runQ: Q = learnN (epochs, initQ).head
 
   override def run: Policy = qToPolicy (this.runQ)

--- a/src/main/scala/symsim/concrete/Randomized.scala
+++ b/src/main/scala/symsim/concrete/Randomized.scala
@@ -45,7 +45,6 @@ object Randomized:
     for i <- between (0, choices.size) yield choices (i)
 
 
-  // TODO: Car seems to have instances in breaking, perhaps we should move these
   given randomizedIsMonad: cats.Monad[Randomized] =
     cats.instances.lazyList.catsStdInstancesForLazyList
 

--- a/src/test/scala/symsim/concrete/ConcreteSarsaIsSarsaSpec.scala
+++ b/src/test/scala/symsim/concrete/ConcreteSarsaIsSarsaSpec.scala
@@ -16,7 +16,6 @@ class ConcreteSarsaIsSarsaSpec extends SymSimSpec:
     gamma = 1.0,
     epsilon = 0.05,
     epochs = 5000,
-    seed = 1000
   )
 
   checkAll ("concrete.ConcreteSarsa is Sarsa",

--- a/src/test/scala/symsim/concrete/ConcreteSarsaSpec.scala
+++ b/src/test/scala/symsim/concrete/ConcreteSarsaSpec.scala
@@ -1,0 +1,56 @@
+package symsim
+package concrete
+
+import symsim.concrete.ConcreteSarsa
+import cats.Monad
+
+class ConcreteSarsaSpec
+  extends org.scalatest.freespec.AnyFreeSpec
+  with org.scalatest.matchers.should.Matchers:
+
+   // Import evidence that states and actions can be enumerated
+   import UnitAgent._
+
+   val sarsa = ConcreteSarsa[
+      UnitState,
+      UnitState,
+      UnitAction
+   ] (
+      agent = UnitAgent,
+      alpha = 0.1,
+      gamma = 0.1,
+      epsilon = 0.2, // explore vs exploit ratio
+      epochs = 150000,
+   )
+
+   val C = 555555
+
+   "This should stack overflow (checking the stack size)" in {
+      def h (n: Int): Int = if n == 0 then 1 else h(n-1) + 1
+      assertThrows[java.lang.StackOverflowError] { h (C) }
+   }
+
+   "This shouldn't overflow stack (ItereateUntilM with learn1 is tailrec, each episode tailrec)"  in {
+      var c = C
+      val p = { (qs: (sarsa.Q,UnitState)) => c = c - 1; c == 0  }
+      val initial = sarsa.initQ -> ()
+      val f = (sarsa.learn1 _).tupled
+      summon[Monad[Randomized]]
+        .iterateUntilM[(sarsa.Q,UnitState)] (initial) (f) (p)
+        .map { _._1 }
+        .head
+   }
+
+
+   "initQ terminates (regression)"  in {
+      sarsa.initQ
+   }
+
+   "learn is tail recursive (regression)"  in {
+      sarsa.learn (sarsa.initQ).head
+      // this test does not really prove the tail recursiveness
+   }
+
+   "runQ is tail recursive (regression)"  in {
+      sarsa.learnN (sarsa.epochs, sarsa.initQ).head
+   }

--- a/src/test/scala/symsim/concrete/RandomizedSpec.scala
+++ b/src/test/scala/symsim/concrete/RandomizedSpec.scala
@@ -26,9 +26,8 @@ class RandomizedSpec extends org.scalatest.freespec.AnyFreeSpec
       forAll { (mn: (Int, Int)) =>
         val m = Math.min (mn._1, mn._2)
         val n = Math.max (mn._1, mn._2)
-        val between = Randomized.between (m, n)
         m != n ==>
-          forAll (between.toGen) { x => m <= x && x < n }
+          forAll (Randomized.between (m, n).toGen) { x => m <= x && x < n }
       }
     }
 

--- a/src/test/scala/symsim/concrete/UnitAgent.scala
+++ b/src/test/scala/symsim/concrete/UnitAgent.scala
@@ -1,0 +1,42 @@
+package symsim
+package concrete
+
+import cats.{Eq, Monad}
+import cats.kernel.BoundedEnumerable
+
+import org.scalacheck.Gen
+import org.scalacheck.Arbitrary
+
+import symsim.concrete.Randomized
+
+type UnitState = Unit
+type UnitAction = Unit
+type UnitReward = Double
+
+object UnitAgent
+   extends Agent[UnitState, UnitState, UnitAction, UnitReward, Randomized]:
+      override def isFinal (s: UnitState): Boolean = true
+      override def discretize (s: UnitState): UnitState =  s
+      override def step (s: UnitState) (a: UnitAction): Randomized[(UnitState, UnitReward)] =
+        Randomized.const (() -> 0.0)
+      override def initialize: Randomized[UnitState] = Randomized.const (())
+      override def zeroReward: UnitReward = 0.0
+      override val instances = UnitInstances
+
+
+/** Here is a proof that our types actually deliver on everything that an Agent
+  * needs to be able to do to work in the framework.
+  */
+object UnitInstances
+   extends AgentConstraints[UnitState, UnitState, UnitAction, UnitReward, Randomized]:
+   given enumAction: BoundedEnumerable[UnitAction] = BoundedEnumerableFromList (())
+   given enumState: BoundedEnumerable[UnitState] = BoundedEnumerableFromList (())
+   given schedulerIsMonad: Monad[Randomized] =
+      concrete.Randomized.randomizedIsMonad
+   given canTestInScheduler: CanTestIn[Randomized] =
+      concrete.Randomized.canTestInRandomized
+   lazy val genUnitState: Gen[UnitState] = Gen.const (())
+   given arbitraryState: Arbitrary[UnitState] = Arbitrary (genUnitState)
+   given eqUnitState: Eq[UnitState] = Eq.fromUniversalEquals
+   given arbitraryReward: Arbitrary[UnitReward] = Arbitrary (Gen.double)
+   given rewardArith: Arith[UnitReward] = Arith.given_Arith_Double

--- a/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
+++ b/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
@@ -1,0 +1,37 @@
+package symsim
+package concrete
+
+import symsim.concrete.ConcreteSarsa
+import org.typelevel.paiges.Doc
+
+class UnitAgentExperiments
+  extends org.scalatest.freespec.AnyFreeSpec
+  with org.scalatest.matchers.should.Matchers
+  with org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+  with org.scalatest.prop.TableDrivenPropertyChecks:
+
+  "test run (should not crash)" in {
+
+    // Import evidence that states and actions can be enumerated
+    import UnitAgent._
+
+    val sarsa = ConcreteSarsa[
+      UnitState,
+      UnitState,
+      UnitAction
+    ] (
+      agent = UnitAgent,
+      alpha = 0.1,
+      gamma = 0.1,
+      epsilon = 0.05, // explore vs exploit ratio
+      epochs = 15000,
+    )
+
+    val q = sarsa.runQ
+    val policy = sarsa.qToPolicy (q)
+    val policy_output = sarsa.pp_policy (policy).hang (4)
+    info (policy_output.render (80))
+    val q_output = sarsa.pp_Q (q).hang (4)
+    info (q_output.render (80))
+
+  }

--- a/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
+++ b/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
@@ -24,7 +24,7 @@ class UnitAgentExperiments
       alpha = 0.1,
       gamma = 0.1,
       epsilon = 0.05, // explore vs exploit ratio
-      epochs = 5000,
+      epochs = 15000,
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
+++ b/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
@@ -24,7 +24,7 @@ class UnitAgentExperiments
       alpha = 0.1,
       gamma = 0.1,
       epsilon = 0.05, // explore vs exploit ratio
-      epochs = 10000,
+      epochs = 5000,
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
+++ b/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
@@ -24,7 +24,7 @@ class UnitAgentExperiments
       alpha = 0.1,
       gamma = 0.1,
       epsilon = 0.05, // explore vs exploit ratio
-      epochs = 15000,
+      epochs = 10000,
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
@@ -25,7 +25,6 @@ class Experiments
       gamma = 0.1,
       epsilon = 0.05, // explore vs exploit ratio
       epochs = 5000,
-      seed = 1000
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
@@ -4,7 +4,7 @@ package examples.concrete.breaking
 import symsim.concrete.ConcreteSarsa
 import org.typelevel.paiges.Doc
 
-class Experiments
+class BreakingExperiments
   extends org.scalatest.freespec.AnyFreeSpec
   with org.scalatest.matchers.should.Matchers
   with org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -24,7 +24,7 @@ class Experiments
       alpha = 0.1,
       gamma = 0.1,
       epsilon = 0.05, // explore vs exploit ratio
-      epochs = 5000,
+      epochs = 100000,
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
@@ -24,7 +24,6 @@ class Experiments
       gamma = 0.1,
       epsilon = 0.05, // explore vs exploit ration.
       epochs = 5000,
-      seed = 1000
     )
 
     val policy = sarsa.run

--- a/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
@@ -3,7 +3,7 @@ package examples.concrete.mountaincar
 
 import symsim.concrete.ConcreteSarsa
 
-class Experiments
+class MountainCarExperiments
   extends org.scalatest.freespec.AnyFreeSpec
   with org.scalatest.matchers.should.Matchers
   with org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -23,7 +23,7 @@ class Experiments
       alpha = 0.1,
       gamma = 0.1,
       epsilon = 0.05, // explore vs exploit ration.
-      epochs = 5000,
+      epochs = 100000,
     )
 
     val policy = sarsa.run

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -20,8 +20,8 @@ class Experiments
       agent = Maze,
       alpha = 0.1,
       gamma = 1.0,
-      epsilon = 0.0, // explore vs exploit ratio
-      epochs = 15000,
+      epsilon = 0.05, // explore vs exploit ratio
+      epochs = 8000,
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -18,11 +18,10 @@ class Experiments
       MazeAction
     ] (
       agent = Maze,
-      alpha = 0.2,
+      alpha = 0.1,
       gamma = 1.0,
       epsilon = 0.0, // explore vs exploit ratio
-      epochs = 5000,
-      seed = 1000
+      epochs = 15000,
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -21,7 +21,7 @@ class Experiments
       alpha = 0.1,
       gamma = 1.0,
       epsilon = 0.05, // explore vs exploit ratio
-      epochs = 8000,
+      epochs = 5000,
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -4,7 +4,7 @@ package examples.concrete.simplemaze
 import symsim.concrete.ConcreteSarsa
 import org.typelevel.paiges.Doc
 
-class Experiments
+class SimpleMazeExperiments
   extends org.scalatest.freespec.AnyFreeSpec
   with org.scalatest.matchers.should.Matchers
   with org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -21,7 +21,7 @@ class Experiments
       alpha = 0.1,
       gamma = 1.0,
       epsilon = 0.05, // explore vs exploit ratio
-      epochs = 5000,
+      epochs = 100000,
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
@@ -24,8 +24,7 @@ class Experiments
       alpha = 0.1,
       gamma = 0.1,
       epsilon = 0.1, // explore vs exploit ration.
-      epochs = 100000,
-      seed = 1000
+      epochs = 10000
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
@@ -4,7 +4,7 @@ package examples.concrete.windygrid
 import symsim.concrete.ConcreteSarsa
 import examples.concrete.windygrid.GridAction._
 
-class Experiments
+class WindyGridExperiments
   extends org.scalatest.freespec.AnyFreeSpec
   with org.scalatest.matchers.should.Matchers
   with org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -24,7 +24,7 @@ class Experiments
       alpha = 0.1,
       gamma = 0.1,
       epsilon = 0.1, // explore vs exploit ration.
-      epochs = 5000
+      epochs = 100000
     )
 
     val q = sarsa.runQ

--- a/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
@@ -24,7 +24,7 @@ class Experiments
       alpha = 0.1,
       gamma = 0.1,
       epsilon = 0.1, // explore vs exploit ration.
-      epochs = 10000
+      epochs = 5000
     )
 
     val q = sarsa.runQ


### PR DESCRIPTION
I had some bugs but they were apparently related to dirty build cache (sbt clean fixed it for me).   The learning with Secure Random seems to be stable. It works for many values of alpha above 0.2, but it has another problem.  The `LazyList` implementation has some tail recursion problems: the implementation overflows stack for a bit more than 15000 epochs (definitely fails for me with 16000). 

I included a `UnitAgent` in this PR and the corresponding `UnitAgentExperiment`. Even this trivial system overflows the stack with 16000 epochs. I will try to debug this issue further, but it appears to be only indirectly related.  We may want to merge this PR anyways and fix the tail recursion separately.   I solicit comments and questions.  We can also discuss it in our online meeting next time. 