### PR TITLE
Minor fixes in MountainCar and SimpleBandit

### DIFF
--- a/src/main/scala/symsim/laws/AgentLaws.scala
+++ b/src/main/scala/symsim/laws/AgentLaws.scala
@@ -6,7 +6,7 @@ import cats.syntax.functor.*
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop
-import org.scalacheck.Prop.forAll
+import org.scalacheck.Prop.*
 
 import symsim.CanTestIn.*
 
@@ -16,47 +16,62 @@ import symsim.CanTestIn.*
   * agents.
   */
 case class AgentLaws[State, ObservableState, Action, Reward, Scheduler[_]]
-   (agent: Agent[State, ObservableState, Action, Reward, Scheduler])
-   extends org.typelevel.discipline.Laws:
+  (agent: Agent[State, ObservableState, Action, Reward, Scheduler])
+  extends org.typelevel.discipline.Laws:
 
-   import agent.instances.given
+  import agent.instances.given
 
-   val finiteStates = agent.instances.enumState.membersAscending
+  val finiteStates = agent.instances.enumState.membersAscending
 
-   val laws: RuleSet = new SimpleRuleSet (
-      "agent",
+  val laws: RuleSet = SimpleRuleSet (
+    "agent",
 
-      /** Law: Every state from the environment/agent state space can
-        * be discretized and represented in the enumerable finite state
-        * space that the agent uses for learning and for control decisions.
-        */
-      "discretize (s) ∈ ObservableState" ->
-      forAll { (s: State) =>
-         finiteStates.contains (agent.discretize (s)) },
+    /** Law: Every state from the environment/agent state space can
+      * be discretized and represented in the enumerable finite state
+      * space that the agent uses for learning and for control decisions.
+      */
+    "discretize (s) ∈ ObservableState" ->
+    forAll { (s: State) =>
+      finiteStates.contains (agent.discretize (s)) },
 
-      /** Law: Every initialization ends up being discritized to
-       *  an enumerable value of ObservableState.
-       */
-      "discretize (initialize) ∈ ObservableState" ->
-      forAll (agent.initialize.toGen) { (s: State) =>
-         finiteStates.contains (agent.discretize (s)) },
+    /** Law: Every initialization ends up being discritized to
+     *  an enumerable value of ObservableState.
+     */
+    "discretize (initialize) ∈ ObservableState" ->
+    forAll (agent.initialize.toGen) { (s: State) =>
+      finiteStates.contains (agent.discretize (s)) },
 
-      /** Law: Initial state is not final, regardless scheduler. */
-      "¬isFinal (initialize)" ->
-      forAll (agent.initialize.toGen) { (s: State) =>
-         !agent.isFinal (s) },
+    /** Law: Initial state is not final, regardless scheduler. */
+    "¬isFinal (initialize)" ->
+    forAll (agent.initialize.toGen) { (s: State) =>
+      !agent.isFinal (s) },
 
-      /** Law: An agent step from any state lands in a state
-        * that be discretized into ObservableState.
-        */
-      "discretize (step (s) (a)._1) ∈ ObservableState" ->
-      forAll { (s0: State) =>
-         forAll { (a: Action) =>
-            val prop = for
-               s1r <- agent.step (s0) (a)
-               (s1, r) = s1r
-               d1 = agent.discretize (s1)
-            yield finiteStates contains d1
-            prop.toProp
-      } },
-   )
+    /** Law: An agent step from any state lands in a state
+      * that be discretized into ObservableState.
+      */
+    "discretize (step (s) (a)._1) ∈ ObservableState" ->
+    forAll { (s0: State) =>
+      forAll { (a: Action) =>
+        val prop = for
+          s1r <- agent.step (s0) (a)
+          (s1, r) = s1r
+          d1 = agent.discretize (s1)
+        yield finiteStates contains d1
+        prop.toProp
+    } },
+
+    /** Law: The initial state is not a fixed point of the step function. So
+     *  an exploration is possible from the initial state. 
+     */
+    "∀ s ∈ initialize ⋅ ∀ a ∈ Actions ⋅ step (s) (a) ≠ (s,_)" ->
+    forAll (agent.initialize.toGen) { (s: State) =>
+      exists { (a: Action) => 
+        val prop = for sr <- agent.step (s) (a) yield sr._1 != s
+        prop.toProp
+    } }
+    // When we add non-episodic tasks this should become: there is at least two
+    // actions that have a different reward, or at least one that leads to a
+    // new state. Otherwise the test will fail on agents that have a singleton
+    // statespace but a reward distribution to learn. It works for our
+    // SimpleBandit, because we implemented it as episodic (with two states).
+  )


### PR DESCRIPTION
During debugging the termination of MountainCar learning I have made the following changes:
 

- MountainCar: Fix whitespace issues and get closer to https://mpatacchiola.github.io/blog/2017/08/14/dissecting-reinforcement-learning-6.html (there were some differences in constants, and boundary values for the state space; since the blog's version supposedly behaves well, I changed our constants to be consistent. Also the velocity is set to zero (as in the blog), when the car falls of the left cliff).
- AgentLaws: Add the test enforcing that step is able to leave the initial state (and fix indentation)
- SimpleBandit: Refactor to simplify    
    - Remove the observable type (it is not needed)
    - Remove the successor function (no need for a constant private function)
    - Remove a "Boolean == true" condition
    - Simplify the initialization (there is only one possible initial state)
    - Add explicit override annotations to make it clear which members are required
    - Wrap some overly long lines and fix other whitespace issues

