### PR TITLE
Mitigate issues with not-properly-random initialization of agents (Issue #128)

### DIFF
--- a/src/main/scala/symsim/CanTestIn.scala
+++ b/src/main/scala/symsim/CanTestIn.scala
@@ -24,7 +24,7 @@ trait CanTestIn[F[_]]:
     * may be falsely assuming that we are testing on random values, but we are
     * testing on scheduled values only.
     */
-  def toGen[A] (fa: F[A]): Gen[A]
+   def toGen[A] (fa: => F[A]): Gen[A]
 
 
 object CanTestIn:

--- a/src/main/scala/symsim/ExactRL.scala
+++ b/src/main/scala/symsim/ExactRL.scala
@@ -70,7 +70,7 @@ trait ExactRL[State, ObservableState, Action, Reward, Scheduler[_]]
      * abstract? Or is qToPolicy too concrete to be here?
      */
    def qToPolicy (q: Q) (using Ordering[Reward]): Policy =
-     def best (m: Map[Action,Reward]): Action =
+     def best (m: Map[Action, Reward]): Action =
        m.map { _.swap } (m.values.max)
      q.view.mapValues (best).to (Map)
 
@@ -84,7 +84,7 @@ trait ExactRL[State, ObservableState, Action, Reward, Scheduler[_]]
         rewards <- Gen.sequence[List[Reward], Reward]
           { List.fill (as.size) (genReward) }
         ars = as zip rewards
-      yield Map (ars: _*)
+      yield Map (ars*)
 
       val fs = agent.instances.allObservableStates
       val genStateActionRewards: Gen[Q] = for
@@ -92,7 +92,7 @@ trait ExactRL[State, ObservableState, Action, Reward, Scheduler[_]]
         mars <- Gen.sequence[List[Map[Action,Reward]], Map[Action,Reward]]
           { List.fill (fs.size) (genActionReward) }
         smars = fs zip mars
-      yield Map (smars: _*)
+      yield Map (smars*)
 
       genStateActionRewards
 

--- a/src/main/scala/symsim/concrete/Randomized.scala
+++ b/src/main/scala/symsim/concrete/Randomized.scala
@@ -26,8 +26,12 @@ type Probability = Double
   **/
 object Randomized:
 
-   /** Create a generator that always a. Used to create deterministic
-     * values when a scheduler/randomized type is expected.
+   def __FORCED[A] (ra: =>Randomized[A]): Randomized[A] = 
+   { print ("FORCED!\n"); ra }
+
+   /** Create a generator that produces a single 'a'. Used to create
+     * deterministic values when a scheduler/randomized type is
+     * expected.
      */
    def const[A] (a: =>A): Randomized[A] =
      LazyList (a)
@@ -36,6 +40,9 @@ object Randomized:
       LazyList (SecureRandom ().nextDouble)
 
 
+   /** Produce a single random number between the bounds, 
+     * right exclusive 
+     **/
    def between (minInclusive: Int, maxExclusive: Int): Randomized[Int] =
       LazyList (SecureRandom ()
          .ints (minInclusive, maxExclusive)
@@ -80,7 +87,7 @@ object Randomized:
          // to add a completely new generator for scalacheck that encapsulates
          // Randomized.  The Gen class appears to be sealed and pimping cannot add
          // state to objects?
-         def toGen[A] (ra: Randomized[A]): Gen[A] =
+         def toGen[A] (ra: => Randomized[A]): Gen[A] =
             require (ra.nonEmpty)
             val stream = repeat (ra)
             Gen.choose(0, 1000)

--- a/src/main/scala/symsim/examples/concrete/breaking/Car.scala
+++ b/src/main/scala/symsim/examples/concrete/breaking/Car.scala
@@ -59,8 +59,8 @@ object Car
 
 
     def initialize: Randomized[CarState] = for
-      v <- Randomized.between (0.0, 10.0)
-      p <- Randomized.between (0.0, 15.0)
+      v <- Randomized.repeat (Randomized.between (0.0, 10.0))
+      p <- Randomized.repeat (Randomized.between (0.0, 15.0))
       s0 = CarState (v,p)
       s <- if isFinal (s0) then initialize
            else Randomized.const (s0)

--- a/src/main/scala/symsim/examples/concrete/golf/Golf.scala
+++ b/src/main/scala/symsim/examples/concrete/golf/Golf.scala
@@ -91,7 +91,7 @@ object Golf
          yield (newState, golfReward (s) (action))
 
       def initialize: Randomized[GolfState] =
-         Randomized.const(1)
+         Randomized.const (1)
 
       override def zeroReward: GolfReward = 0
 

--- a/src/main/scala/symsim/examples/concrete/mountaincar/MountainCar.scala
+++ b/src/main/scala/symsim/examples/concrete/mountaincar/MountainCar.scala
@@ -72,9 +72,9 @@ object MountainCar
 
 
   def initialize: Randomized[CarState] = for
-    v <- Randomized.between (-1.5, 1.5)
-    p <- Randomized.between (-1.2, 0.5)
-    s0 = CarState (v = v, p = p)
+    p <- Randomized.repeat (Randomized.between (-1.2, 0.5))
+    v <- Randomized.repeat (Randomized.between (-1.5, 1.5))
+    s0 = CarState (v, p)
     s <- if isFinal (s0) then initialize else Randomized.const (s0)
   yield s
 

--- a/src/main/scala/symsim/examples/concrete/mountaincar/MountainCar.scala
+++ b/src/main/scala/symsim/examples/concrete/mountaincar/MountainCar.scala
@@ -19,7 +19,9 @@ import symsim.concrete.Randomized
  * the same type to represent the finite state space.
  */
 
-case class CarState (v: Double, p: Double)
+case class CarState (v: Double, p: Double):
+  override def toString: String = f"[v $v%+2.2f, p $p%+2.2f]"
+
 type CarObservableState = CarState
 type CarAction = Double
 type CarReward = Double

--- a/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
+++ b/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
@@ -90,7 +90,11 @@ object Maze
          yield (newState, mazeReward (newState))
 
       def initialize: Randomized[MazeState] =
-         Randomized.oneOf (instances.allObservableStates.filter { !isFinal (_) }:_*)
+         Randomized.repeat { 
+           Randomized.oneOf ( 
+             instances.allObservableStates.filter { !isFinal (_) } : _*
+           )
+         }
 
       override def zeroReward: MazeReward = 0
 

--- a/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
+++ b/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
@@ -60,7 +60,7 @@ object Maze
       private def mazeReward (s: MazeState): MazeReward = s match
         case (4, 3) => 1.0   // Good final state
         case (4, 2) => -1.0  // Bad final state
-        case (_, _) => -0.04
+        case (_, _) => -0.02
 
 
       def distort (a: MazeAction): Randomized[MazeAction] = a match
@@ -92,7 +92,7 @@ object Maze
       def initialize: Randomized[MazeState] =
          Randomized.repeat { 
            Randomized.oneOf ( 
-             instances.allObservableStates.filter { !isFinal (_) } : _*
+             instances.allObservableStates.filter { s => !isFinal (s) } *
            )
          }
 

--- a/src/main/scala/symsim/examples/concrete/windygrid/WindyGrid.scala
+++ b/src/main/scala/symsim/examples/concrete/windygrid/WindyGrid.scala
@@ -9,7 +9,9 @@ import org.scalacheck.{Arbitrary, Gen}
 
 import symsim.concrete.Randomized
 
-case class GridState (x: Int, y: Int)
+case class GridState (x: Int, y: Int):
+  override def toString: String = s"($x,$y)"
+  
 type GridObservableState = GridState
 type GridReward = Double
 

--- a/src/main/scala/symsim/examples/concrete/windygrid/WindyGrid.scala
+++ b/src/main/scala/symsim/examples/concrete/windygrid/WindyGrid.scala
@@ -65,8 +65,8 @@ object WindyGrid
        Randomized.const (s1 -> GridReward (s1) (a))
 
     def initialize: Randomized[GridState] = for
-       x <- Randomized.between (1, 11)
-       y <- Randomized.between (1, 8)
+       x <- Randomized.repeat (Randomized.between (1, 11))
+       y <- Randomized.repeat (Randomized.between (1, 8))
        s0 = GridState (x, y)
        s <- if isFinal (s0) then initialize else Randomized.const (s0)
     yield s

--- a/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
@@ -12,7 +12,7 @@ class Experiments
      alpha = 0.1,
      gamma = 0.1,
      epsilon = 0.05,
-     episodes = 0,
+     episodes = 3,
    )
 
    s"MountainCar experiment with $sarsa" in {

--- a/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
@@ -12,7 +12,7 @@ class Experiments
      alpha = 0.1,
      gamma = 0.1,
      epsilon = 0.05,
-     episodes = 3,
+     episodes = 80000,
    )
 
    s"MountainCar experiment with $sarsa" in {

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -9,26 +9,33 @@ class Experiments
      alpha = 0.1,
      gamma = 1.0,
      epsilon = 0.05,
-     episodes = 30000,
+     episodes = 70000,
    )
 
    s"SimpleMaze experiment with ${sarsa}" in {
 
       val policy = learnAndLog (sarsa)
 
-      val groundTruth = List (
-         (1,1) -> Up,
-         (1,2) -> Up,
-         (1,3) -> Right,
-         (2,1) -> Left,
-         (2,3) -> Right,
-         (3,1) -> Left,
-         (3,2) -> Up,
-         (3,3) -> Right,
-         (4,1) -> Left,
-         (4,2) -> Right,
-         (4,3) -> Right,
-      ).toMap
+      withClue ("1,1") { policy (1, 1) should be (Up) }
+      withClue ("1,2") { policy (1, 2) should be (Up) }
+      withClue ("1,3") { policy (1, 3) should be (Right) }
+      withClue ("2,1") { policy (2, 1) should be (Left) }
+      withClue ("2,3") { policy (2, 3) should be (Right) }
 
-      policy should be (groundTruth)
+      // We leave 4,3 and 4,2 unconstrained (loosing and winning,
+      // final states)
+      
+      // Which of policy is optimal is a bit hard to
+      // establish, and depends on the constants in the reward
+      // function. We include several options to decrease flakiness of
+      // tests (mostly positions in column 3 are sensitive)
+
+      // this appears to be still a good move
+      withClue ("3,1") { policy (3,1) should be (Left) }
+      // Left is safest but AIAMA reports the dangerous Up
+      withClue ("3,2") { policy (3,2) should (be (Left) or be (Up))  }
+      // Up is safest but AIAMA reports the somewhat risky Right
+      withClue ("3,3") { policy (3,3) should (be (Up) or be (Right)) }
+      // Left is faster, down is safer
+      withClue ("4,1") { policy (4, 1) should (be (Down) or be (Left)) }
    }

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -9,7 +9,7 @@ class Experiments
      alpha = 0.1,
      gamma = 1.0,
      epsilon = 0.05,
-     episodes = 25000,
+     episodes = 30000,
    )
 
    s"SimpleMaze experiment with ${sarsa}" in {


### PR DESCRIPTION
Apologies for creating a pull request with a few unrelated issues:

- The main goal is to mitigate issue #128 . I fixed how `initialize` works in `MountainCar` and in other models. Now they produce a stream of random initial states, not  singleton random state. This allows the tests using `initialize` to test on several random initial states, not just on a single random initial state several times.  It does not close issue #128 - the right solution would be to design an API for `Randomized` that does not make a difference whether `repeat` is called directly on a `Randomized` expression or after binding a value to some name. However currently this is a bit off topic. Instead I reviewed all the code and convinced myself that other places (other tests, not using `initialize`, and the learning algorithms) are not affected by this issue.
- Merging this and `main` (via rebasing) also made the experiments for `MountainCar` to work (with upto ca. 100K episodes).
- I have improved policy and Q-Table printing for some models
- Fixed some white space issues (formatting).

Please review, test, and revert to me (or merge). 