### PR TITLE
Migrate to Scala 3.1.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ val catsVersion = "2.6.1"
 scalacOptions ++= Seq (
   "-deprecation",
   "-feature",
-  "-Xfatal-warnings",
   "-Yindent-colons",
+  "-source:future",
 )
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 name := "symsim"
 
-ThisBuild / scalaVersion := "3.0.1"
+ThisBuild / scalaVersion := "3.1.3"
 
-val scalatestVersion = "3.2.10"
+val scalatestVersion = "3.2.14"
 val catsVersion = "2.6.1"
 
 
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq (
   "org.scalatest" %% "scalatest-freespec" % scalatestVersion % Test,
   "org.scalatest" %% "scalatest-shouldmatchers" % scalatestVersion % Test,
   "org.scalatest" %% "scalatest-mustmatchers" % scalatestVersion % Test,
-  "org.scalatestplus" %% "scalacheck-1-15" % (scalatestVersion+".0") % Test,
+  "org.scalatestplus" %% "scalacheck-1-17" % (scalatestVersion+".0") % Test,
   "org.typelevel" %% "cats-core" % catsVersion,
   "org.typelevel" %% "cats-laws" % catsVersion,
   "org.typelevel" %% "discipline-scalatest" % "2.1.5",

--- a/src/main/scala/symsim/Agent.scala
+++ b/src/main/scala/symsim/Agent.scala
@@ -3,7 +3,7 @@ package symsim
 import org.scalacheck.{Arbitrary, Gen}
 
 import cats.{Foldable, Monad}
-import cats.syntax.functor._
+import cats.syntax.functor.*
 import cats.kernel.BoundedEnumerable
 
 /** TODO: A possible refactoring: separate Agents from finite agents, where the

--- a/src/main/scala/symsim/QTable.scala
+++ b/src/main/scala/symsim/QTable.scala
@@ -41,7 +41,7 @@ trait QTable[State, ObservableState, Action, Reward, Scheduler[_]]
       rewards <- Gen.sequence[List[Reward], Reward] {
         List.fill (as.size) (genReward) }
       ars = as zip rewards
-    yield Map (ars: _*)
+    yield Map (ars*)
 
     val fs = agent.instances.allObservableStates
     val genStateActionRewards: Gen[Q] = for

--- a/src/main/scala/symsim/RL.scala
+++ b/src/main/scala/symsim/RL.scala
@@ -1,7 +1,7 @@
 package symsim
 
 import cats.kernel.BoundedEnumerable
-import cats.syntax.option._
+import cats.syntax.option.*
 import org.typelevel.paiges.Doc
 
 trait RL[ObservableState, Action]:

--- a/src/main/scala/symsim/concrete/ConcreteQTable.scala
+++ b/src/main/scala/symsim/concrete/ConcreteQTable.scala
@@ -15,6 +15,7 @@ trait ConcreteQTable[State, ObservableState, Action]
     val qs = q (agent.discretize (s)) map { _.swap }
     qs (qs.keys.max)
 
+
   def chooseAction (q: Q) (s: State): Randomized[Action] =
     for
       explore <- Randomized.coin (this.epsilon)
@@ -32,6 +33,7 @@ trait ConcreteQTable[State, ObservableState, Action]
   override def run: Policy =
     qToPolicy (this.runQ)
 
+
   /** Convert the matrix Q after training into a Policy map. TODO: should not
     * this be using the bestAction method? Or, why is the best action method
     * abstract? Or is qToPolicy too concrete to be here?
@@ -40,7 +42,6 @@ trait ConcreteQTable[State, ObservableState, Action]
     def best (m: Map[Action, Double]): Action =
       m.map { _.swap } (m.values.max)
     q.view.mapValues (best).to (Map)
-
 
 
   /** We assume that all values define the same set of actions valuations.  */

--- a/src/main/scala/symsim/concrete/ConcreteQTable.scala
+++ b/src/main/scala/symsim/concrete/ConcreteQTable.scala
@@ -30,6 +30,7 @@ trait ConcreteQTable[State, ObservableState, Action]
     val schedule = learn (this.initialize, initials)
     schedule.head
 
+
   override def run: Policy =
     qToPolicy (this.runQ)
 

--- a/src/main/scala/symsim/concrete/Randomized.scala
+++ b/src/main/scala/symsim/concrete/Randomized.scala
@@ -3,7 +3,7 @@ package symsim.concrete
 import cats.data.State
 import org.scalacheck.{Gen, Prop}
 
-import scala.jdk.StreamConverters._
+import scala.jdk.StreamConverters.*
 import scala.util.Try
 
 import java.security.SecureRandom

--- a/src/main/scala/symsim/examples/concrete/breaking/Car.scala
+++ b/src/main/scala/symsim/examples/concrete/breaking/Car.scala
@@ -23,10 +23,24 @@ object Car
   extends Agent[CarState, CarObservableState, CarAction, CarReward, Randomized]
   with Episodic:
 
+    /** The episode should be guaranteed to terminate after
+      * TimeHorizon steps. This is used *only* *for* testing. It does
+      * not actually termintae the episodes. It is a bug if they run
+      * longer.
+      */
     val TimeHorizon: Int = 2000
 
+    /** Granularity of the step in seconds */
+    private val t: Double = 2.0
+
+    /** Evidence of type class membership for this agent. */
+    val instances = CarInstances
+
+    override val zeroReward: CarReward = 0.0
+ 
+
     def isFinal (s: CarState): Boolean =
-      s.v == 0.0 || Math.abs (s.p) >= 1000.0
+      s.v == 0.0 || s.p >= 10 || Math.abs (s.p) >= 1000.0
 
 
     def discretize (s: CarState): CarObservableState =
@@ -43,9 +57,6 @@ object Car
       if s.p >= 10.0 then -100
       else a
 
-
-    /** Granularity of the step in seconds */
-    private val t: Double = 2.0
 
     // TODO: this is now deterministic but eventually needs to be randomized
     def step (s: CarState) (a: CarAction): Randomized[(CarState, CarReward)] =
@@ -65,11 +76,6 @@ object Car
       s <- if isFinal (s0) then initialize
            else Randomized.const (s0)
     yield s
-
-
-    override def zeroReward: CarReward = 0.0
-
-    val instances = CarInstances
 
 end Car
 

--- a/src/main/scala/symsim/examples/concrete/breaking/Car.scala
+++ b/src/main/scala/symsim/examples/concrete/breaking/Car.scala
@@ -101,7 +101,7 @@ object CarInstances
       v <- Seq (0.0, 5.0, 10.0)
       p <- Seq (0.0, 5.0, 10.0, 15.0)
     yield CarState (v,p)
-    BoundedEnumerableFromList (ss: _*)
+    BoundedEnumerableFromList (ss*)
 
   given schedulerIsMonad: Monad[Randomized] =
     concrete.Randomized.randomizedIsMonad

--- a/src/main/scala/symsim/examples/concrete/mountaincar/MountainCar.scala
+++ b/src/main/scala/symsim/examples/concrete/mountaincar/MountainCar.scala
@@ -101,7 +101,7 @@ object MountainCarInstances
       p0 <- Seq (-1.2, -1.03, -0.86, -0.69, -0.52, -0.35, -0.18, -0.01, 0.16, 0.33, 0.5)
       v0 <- Seq (-1.5, -1.2, -0.9, -0.6, -0.3, 0.0, 0.3, 0.6, 0.9, 1.2, 1.5)
     yield CarState (v = v0, p = p0)
-    BoundedEnumerableFromList (ss: _*)
+    BoundedEnumerableFromList (ss*)
 
 
   given schedulerIsMonad: Monad[Randomized] = Randomized.randomizedIsMonad

--- a/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
+++ b/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
@@ -119,7 +119,7 @@ object MazeInstances
          result = (x, y)
          if Maze.valid (result)
       yield result
-      BoundedEnumerableFromList (ss: _*)
+      BoundedEnumerableFromList (ss*)
 
    given schedulerIsMonad: Monad[Randomized] = Randomized.randomizedIsMonad
 

--- a/src/main/scala/symsim/examples/concrete/windygrid/WindyGrid.scala
+++ b/src/main/scala/symsim/examples/concrete/windygrid/WindyGrid.scala
@@ -1,7 +1,7 @@
 package symsim
 package examples.concrete.windygrid
 
-import examples.concrete.windygrid.GridAction._
+import examples.concrete.windygrid.GridAction.*
 import cats.{Eq, Foldable, Monad}
 import cats.kernel.BoundedEnumerable
 
@@ -85,8 +85,6 @@ end WindyGrid
 object WindyGridInstances
   extends AgentConstraints[GridState, GridObservableState, GridAction, GridReward, Randomized]:
 
-  import examples.concrete.windygrid.GridAction._
-
   given enumAction: BoundedEnumerable[GridAction] =
     BoundedEnumerableFromList (U, L, R, D)
 
@@ -95,7 +93,7 @@ object WindyGridInstances
          x <- Seq (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
          y <- Seq (1, 2, 3, 4, 5, 6, 7)
      yield GridState (x, y)
-     BoundedEnumerableFromList (ss: _*)
+     BoundedEnumerableFromList (ss*)
 
 
   given schedulerIsMonad: Monad[Randomized] = Randomized.randomizedIsMonad

--- a/src/main/scala/symsim/laws/EpisodicLaws.scala
+++ b/src/main/scala/symsim/laws/EpisodicLaws.scala
@@ -19,7 +19,7 @@ import symsim.CanTestIn.*
 /** Collect the laws that define correctness of an Agent with Episodic.
   **/
 case class EpisodicLaws[State, ObservableState, Action, Reward, Scheduler[_]]
-   (agent: Agent[State, ObservableState, Action, Reward, Scheduler] with Episodic)
+   (agent: Agent[State, ObservableState, Action, Reward, Scheduler] & Episodic)
    extends org.typelevel.discipline.Laws:
 
    import agent.instances.given

--- a/src/test/scala/symsim/BoundedEnumerableFromListSpec.scala
+++ b/src/test/scala/symsim/BoundedEnumerableFromListSpec.scala
@@ -5,21 +5,22 @@ import cats.kernel.laws.discipline.BoundedEnumerableTests
 import org.scalacheck.Gen
 import org.scalacheck.Arbitrary
 
-class BoundedEnumerableFromListSpec extends SymSimSpec:
+class BoundedEnumerableFromListSpec 
+  extends SymSimSpec:
 
-    given BoundedEnumerable[Unit] = BoundedEnumerableFromList (())
+  given BoundedEnumerable[Unit] = BoundedEnumerableFromList (())
 
-    given BoundedEnumerable[Boolean] = BoundedEnumerableFromList (true, false)
+  given BoundedEnumerable[Boolean] = BoundedEnumerableFromList (true, false)
 
-    val l = Seq (1.0, 2.0, 42.0, 0.42)
-    given Arbitrary[Double] = Arbitrary[Double] (Gen.oneOf (l))
-    given BoundedEnumerable[Double] = BoundedEnumerableFromList (l: _*)
+  val l = Seq (1.0, 2.0, 42.0, 0.42)
+  given Arbitrary[Double] = Arbitrary[Double] (Gen.oneOf (l))
+  given BoundedEnumerable[Double] = BoundedEnumerableFromList (l*)
 
-    checkAll ("BoundedEnumerableFromList[Unit]",
-      BoundedEnumerableTests[Unit].boundedEnumerable)
+  checkAll ("BoundedEnumerableFromList[Unit]",
+    BoundedEnumerableTests[Unit].boundedEnumerable)
 
-    checkAll ("BoundedEnumerableFromList[Boolean]",
-      BoundedEnumerableTests[Boolean].boundedEnumerable)
+  checkAll ("BoundedEnumerableFromList[Boolean]",
+    BoundedEnumerableTests[Boolean].boundedEnumerable)
 
-    checkAll ("BoundedEnumerableFromList[4 x Double]",
-      BoundedEnumerableTests[Double].boundedEnumerable)
+  checkAll ("BoundedEnumerableFromList[4 x Double]",
+    BoundedEnumerableTests[Double].boundedEnumerable)

--- a/src/test/scala/symsim/ExperimentSpec.scala
+++ b/src/test/scala/symsim/ExperimentSpec.scala
@@ -1,16 +1,17 @@
 package symsim
 
 import symsim.concrete.ConcreteQTable
-trait ExperimentSpec[State, ObservableState, Action]
-   extends org.scalatest.freespec.AnyFreeSpec
-   with org.scalatest.matchers.should.Matchers:
 
-   def learnAndLog (setup: concrete.ConcreteExactRL[State, ObservableState, Action]
-           with ConcreteQTable[State, ObservableState, Action]) =
-      val q = setup.runQ
-      val policy = setup.qToPolicy (q)
-      val policy_output = setup.pp_policy (policy).hang (4)
-      info (policy_output.render (80))
-      val q_output = setup.pp_Q (q).hang (4)
-      info (q_output.render (80))
-      policy
+trait ExperimentSpec[State, Observable, Action]
+  extends org.scalatest.freespec.AnyFreeSpec,
+    org.scalatest.matchers.should.Matchers:
+
+  def learnAndLog (setup: concrete.ConcreteExactRL[State, Observable, Action]
+    & ConcreteQTable[State, Observable, Action]) =
+    val q = setup.runQ
+    val policy = setup.qToPolicy (q)
+    val policy_output = setup.pp_policy (policy).hang (4)
+    info (policy_output.render (80))
+    val q_output = setup.pp_Q (q).hang (4)
+    info (q_output.render (80))
+    policy

--- a/src/test/scala/symsim/concrete/ConcreteSarsaIsSarsaSpec.scala
+++ b/src/test/scala/symsim/concrete/ConcreteSarsaIsSarsaSpec.scala
@@ -5,14 +5,14 @@ import symsim.examples.concrete.mountaincar.MountainCar
 import symsim.laws.SarsaLaws
 
 class ConcreteSarsaIsSarsaSpec
-   extends SymSimSpec:
+  extends SymSimSpec:
 
-   val csarsa = ConcreteSarsa (
-     agent = MountainCar,
-     alpha = 0.1,
-     gamma = 1.0,
-     epsilon = 0.05,
-     episodes = 500,
-   )
+  val csarsa = ConcreteSarsa (
+    agent = MountainCar,
+    alpha = 0.1,
+    gamma = 1.0,
+    epsilon = 0.05,
+    episodes = 500,
+  )
 
-   checkAll ("concrete.ConcreteSarsa is Sarsa", SarsaLaws (csarsa).laws)
+  checkAll ("concrete.ConcreteSarsa is Sarsa", SarsaLaws (csarsa).laws)

--- a/src/test/scala/symsim/concrete/ConcreteSarsaSpec.scala
+++ b/src/test/scala/symsim/concrete/ConcreteSarsaSpec.scala
@@ -2,52 +2,50 @@ package symsim
 package concrete
 
 class ConcreteSarsaSpec
-  extends org.scalatest.freespec.AnyFreeSpec
-  with org.scalatest.matchers.should.Matchers:
+  extends org.scalatest.freespec.AnyFreeSpec,
+    org.scalatest.matchers.should.Matchers:
 
-   // Import evidence that states and actions can be enumerated
-   import UnitAgent._
+  // Import evidence that states and actions can be enumerated
+  import UnitAgent.*
 
-   val sarsa = ConcreteSarsa (
-      agent = UnitAgent,
-      alpha = 0.1,
-      gamma = 0.1,
-      epsilon = 0.2, // explore vs exploit ratio
-      episodes = 150000,
-   )
+  val sarsa = ConcreteSarsa (
+    agent = UnitAgent,
+    alpha = 0.1,
+    gamma = 0.1,
+    epsilon = 0.2, // explore vs exploit ratio
+    episodes = 150000,
+  )
 
-   val C = 555555
+  val C = 555555
 
-   "This should stack overflow (checking the stack size C)" in {
-      def h (n: Int): Int = if n == 0 then 1 else h (n-1) + 1
-      assertThrows[java.lang.StackOverflowError] { h (C) }
-   }
+  "This should stack overflow (checking the stack size C)" in {
+    def h (n: Int): Int = if n == 0 then 1 else h (n-1) + 1
+    assertThrows[java.lang.StackOverflowError] { h (C) }
+  }
 
-   "learnN shouldn't overflow stack (learnN is tailrec, each episode tailrec)" in {
-       val initials: Randomized[UnitState] = Randomized.repeat (UnitAgent.initialize)
-       val result: Randomized[sarsa.Q] = sarsa.learn (sarsa.initialize, initials.take (C))
-       try result.size == 1
-       catch case e =>
-          fail (s"Forcing result of learning overflows (${e.toString})")
-   }
+  "learnN shouldn't overflow stack (learnN is tailrec, each episode tailrec)" in {
+    val initials: Randomized[UnitState] = Randomized.repeat (UnitAgent.initialize)
+    val result: Randomized[sarsa.Q] = sarsa.learn (sarsa.initialize, initials.take (C))
+    try result.size == 1
+    catch case e =>
+       fail (s"Forcing result of learning overflows (${e.toString})")
+  }
 
 
-   "initQ terminates, no stack overflow (regression)"  in {
-      sarsa.initialize
-   }
+  "initQ terminates, no stack overflow (regression)"  in {
+    sarsa.initialize
+  }
 
-   "learn is tail recursive, no stack overflow (regression)"  in {
-      val result = sarsa.learningEpisode (sarsa.initialize, ())
-      result.head
-      // this test does not really prove the tail recursiveness,
-      // but at least checks for crash
-      // also with the immediate final state 'learn' is not really tested here
-   }
+  "learn is tail recursive, no stack overflow (regression)"  in {
+    val result = sarsa.learningEpisode (sarsa.initialize, ())
+    result.head
+    // this test does not really prove the tail recursiveness,
+    // but at least checks for crash
+    // also with the immediate final state 'learn' is not really tested here
+  }
 
-   "runQ is tail recursive, no stack overflow (regression)"  in {
-      try sarsa.runQ
-      catch case e =>
-         fail (s"sarsa.runQ overflows stack (${e.toString})")
-   }
-
-end ConcreteSarsaSpec
+  "runQ is tail recursive, no stack overflow (regression)"  in {
+    try sarsa.runQ
+    catch case e =>
+       fail (s"sarsa.runQ overflows stack (${e.toString})")
+  }

--- a/src/test/scala/symsim/concrete/RandomizedSpec.scala
+++ b/src/test/scala/symsim/concrete/RandomizedSpec.scala
@@ -7,11 +7,12 @@ import org.scalacheck.Prop.{forAll, forAllNoShrink, propBoolean}
 import org.scalacheck.Gen
 
 import symsim.concrete.Randomized.canTestInRandomized
-import symsim.CanTestIn._
+import symsim.CanTestIn.*
 
 /** Sanity tests for Randomized as a Scheduler */
-class RandomizedSpec extends org.scalatest.freespec.AnyFreeSpec
-   with org.scalatestplus.scalacheck.Checkers:
+class RandomizedSpec 
+  extends org.scalatest.freespec.AnyFreeSpec,
+    org.scalatestplus.scalacheck.Checkers:
 
    val C = 5000
 
@@ -93,7 +94,7 @@ class RandomizedSpec extends org.scalatest.freespec.AnyFreeSpec
       }
 
       "20 consecutive values of oneOf(1..100)* are random (different)" in {
-         assert { repeatNotConstant (Randomized.oneOf (1 to 100: _*)) }
+         assert { repeatNotConstant (Randomized.oneOf (1 to 100*)) }
       }
 
       /* This test records what is the problem with referential transparency in

--- a/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
+++ b/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
@@ -2,33 +2,31 @@ package symsim
 package concrete
 
 class UnitAgentExperiments
-   extends ExperimentSpec[UnitState, UnitState, UnitAction]:
+  extends ExperimentSpec[UnitState, UnitState, UnitAction]:
 
-   // Import evidence that states and actions can be enumerated
-   import UnitAgent._
+  // Import evidence that states and actions can be enumerated
+  import UnitAgent.*
 
-   val sarsa = symsim.concrete.ConcreteSarsa (
-      agent = UnitAgent,
-      alpha = 0.1,
-      gamma = 0.1,
-      epsilon = 0.05, // explore vs exploit ratio
-      episodes = 100,
-   )
+  val sarsa = symsim.concrete.ConcreteSarsa (
+     agent = UnitAgent,
+     alpha = 0.1,
+     gamma = 0.1,
+     epsilon = 0.05, // explore vs exploit ratio
+     episodes = 100,
+  )
 
-   s"UnitAgent test run with $sarsa (should not crash)" in {
-      learnAndLog (sarsa) should be (List (() -> ()).toMap)
-   }
+  s"UnitAgent test run with $sarsa (should not crash)" in {
+     learnAndLog (sarsa) should be (List (() -> ()).toMap)
+  }
 
-   val qLearning = symsim.concrete.ConcreteQLearning (
-      agent = UnitAgent,
-      alpha = 0.1,
-      gamma = 0.1,
-      epsilon = 0.05, // explore vs exploit ratio
-      episodes = 100,
-   )
+  val qLearning = symsim.concrete.ConcreteQLearning (
+     agent = UnitAgent,
+     alpha = 0.1,
+     gamma = 0.1,
+     epsilon = 0.05, // explore vs exploit ratio
+     episodes = 100,
+  )
 
-   s"UnitAgent test run with $qLearning (should not crash)" in {
-       learnAndLog (qLearning) should be (List (() -> ()).toMap)
-   }
-
-
+  s"UnitAgent test run with $qLearning (should not crash)" in {
+      learnAndLog (qLearning) should be (List (() -> ()).toMap)
+  }

--- a/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
@@ -1,63 +1,63 @@
 package symsim
 package examples.concrete.breaking
 
-import CanTestIn._
+import CanTestIn.*
 
-import org.scalatest._
-import prop._
-import org.scalacheck.Arbitrary._
+import org.scalatest.*
+import prop.*
+import org.scalacheck.Arbitrary.*
 import org.scalacheck.Gen
 import org.scalatest.prop.Whenever
-import org.scalatest._
+import org.scalatest.*
 import org.scalacheck.Prop.{forAll, forAllNoShrink, propBoolean, exists}
 import examples.concrete.breaking.CarState
 import examples.concrete.breaking.Car
 
 /** Sanity tests for Randomized as a Scheduler */
 class CarSpec
-   extends org.scalatest.freespec.AnyFreeSpec
-   with org.scalatestplus.scalacheck.Checkers:
+  extends org.scalatest.freespec.AnyFreeSpec,
+    org.scalatestplus.scalacheck.Checkers:
 
-   "Sanity checks for symsim.concrete.breaking" - {
+  "Sanity checks for symsim.concrete.breaking" - {
 
-       // Generators of test data
-       val positions = Gen.choose[Double] (0.0, 10.0)
-       val velocities = Gen.choose[Double] (0.0,10.0)
-       val actions = Gen.oneOf (Car.instances.enumAction.membersAscending)
+    // Generators of test data
+    val positions = Gen.choose[Double] (0.0, 10.0)
+    val velocities = Gen.choose[Double] (0.0,10.0)
+    val actions = Gen.oneOf (Car.instances.enumAction.membersAscending)
 
-       // Tests
+    // Tests
 
-       "The car cannot move backwards" in check {
-          forAll (positions, actions) { (p, a) =>
-             val (s1, r) = Car.step (CarState (v = 0.0, p = p)) (a).head
-             (a <= 0) ==> (s1.p >= p)
-          }
-       }
-
-
-       "Position never becomes negative" in check {
-          forAll (velocities, positions, actions) { (v, p, a) =>
-             val (s1, r) = Car.step (CarState (v = v, p = p)) (a).head
-             s1.p >= 0.0
-          }
-       }
-
-
-       "Reward is valid 1" in check {
-          forAll  (positions, positions, velocities, actions) { (p1, p2, v, a) =>
-             val r1 = Car.step (CarState (v = v, p = p1)) (a).head._2
-             val r2 = Car.step (CarState (v = v, p = p2)) (a).head._2
-             p1 <= p2 ==> r1 >= r2
-          }
-       }
-
-
-       "Reward is valid 2" in check {
-          forAll  (velocities, velocities, positions, actions) { (v1, v2, p, a) =>
-             val r1 = Car.step (CarState (v1, p)) (a).head._2
-             val r2 = Car.step (CarState (v2, p)) (a).head._2
-             v1 <= v2 ==> r1 >= r2
-          }
-       }
-
+    "The car cannot move backwards" in check {
+      forAll (positions, actions) { (p, a) =>
+        val (s1, r) = Car.step (CarState (v = 0.0, p = p)) (a).head
+        (a <= 0) ==> (s1.p >= p)
+      }
     }
+
+
+    "Position never becomes negative" in check {
+      forAll (velocities, positions, actions) { (v, p, a) =>
+        val (s1, r) = Car.step (CarState (v = v, p = p)) (a).head
+        s1.p >= 0.0
+      }
+    }
+
+
+    "Reward is valid 1" in check {
+      forAll  (positions, positions, velocities, actions) { (p1, p2, v, a) =>
+        val r1 = Car.step (CarState (v = v, p = p1)) (a).head._2
+        val r2 = Car.step (CarState (v = v, p = p2)) (a).head._2
+        p1 <= p2 ==> r1 >= r2
+      }
+    }
+
+
+    "Reward is valid 2" in check {
+      forAll  (velocities, velocities, positions, actions) { (v1, v2, p, a) =>
+        val r1 = Car.step (CarState (v1, p)) (a).head._2
+        val r2 = Car.step (CarState (v2, p)) (a).head._2
+        v1 <= v2 ==> r1 >= r2
+      }
+    }
+
+  }

--- a/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
@@ -2,19 +2,19 @@ package symsim
 package examples.concrete.breaking
 
 class Experiments
-   extends ExperimentSpec[CarState, CarObservableState, CarAction]:
+  extends ExperimentSpec[CarState, CarObservableState, CarAction]:
 
-   // Import evidence that states and actions can be enumerated
-   import Car._
+  // Import evidence that states and actions can be enumerated
+  import Car.*
 
-   val sarsa = symsim.concrete.ConcreteSarsa (
-      agent = Car,
-      alpha = 0.1,
-      gamma = 0.1,
-      epsilon = 0.05,
-      episodes = 5000,
-   )
+  val sarsa = symsim.concrete.ConcreteSarsa (
+     agent = Car,
+     alpha = 0.1,
+     gamma = 0.1,
+     epsilon = 0.05,
+     episodes = 100000,
+  )
 
-   s"Breaking Car experiment with $sarsa" in {
-     val policy = learnAndLog (sarsa)
-   }
+  s"Breaking Car experiment with $sarsa" in {
+    val policy = learnAndLog (sarsa)
+  }

--- a/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
@@ -12,7 +12,7 @@ class Experiments
      alpha = 0.1,
      gamma = 0.1,
      epsilon = 0.05,
-     episodes = 100000,
+     episodes = 10000,
   )
 
   s"Breaking Car experiment with $sarsa" in {

--- a/src/test/scala/symsim/examples/concrete/golf/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/golf/Experiments.scala
@@ -2,15 +2,16 @@ package symsim
 package examples.concrete.golf
 
 class Experiments
-   extends ExperimentSpec[GolfState,GolfState,GolfAction]:
-   import Golf._
+  extends ExperimentSpec[GolfState, GolfState, GolfAction]:
 
-   val sarsa = symsim.concrete.ConcreteSarsa (
-     agent = Golf,
-     alpha = 0.1,
-     gamma = 0.1,
-     epsilon = 0.1,
-     episodes = 20000,
-   )
+  import Golf.*
 
-   s"Golf experiment with ${sarsa}" in { val policy = learnAndLog (sarsa) }
+  val sarsa = symsim.concrete.ConcreteSarsa (
+    agent = Golf,
+    alpha = 0.1,
+    gamma = 0.1,
+    epsilon = 0.1,
+    episodes = 20000,
+  )
+
+  s"Golf experiment with ${sarsa}" in { val policy = learnAndLog (sarsa) }

--- a/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/mountaincar/Experiments.scala
@@ -2,19 +2,19 @@ package symsim
 package examples.concrete.mountaincar
 
 class Experiments
-   extends ExperimentSpec[CarState, CarObservableState, CarAction]:
+  extends ExperimentSpec[CarState, CarObservableState, CarAction]:
 
-   // Import evidence that states and actions can be enumerated
-   import MountainCar._
+  // Import evidence that states and actions can be enumerated
+  import MountainCar.*
 
-   val sarsa = symsim.concrete.ConcreteSarsa (
-     agent = MountainCar,
-     alpha = 0.1,
-     gamma = 0.1,
-     epsilon = 0.05,
-     episodes = 80000,
-   )
+  val sarsa = symsim.concrete.ConcreteSarsa (
+    agent = MountainCar,
+    alpha = 0.1,
+    gamma = 0.1,
+    epsilon = 0.05,
+    episodes = 80000,
+  )
 
-   s"MountainCar experiment with $sarsa" in {
-     val policy = learnAndLog (sarsa)
-   }
+  s"MountainCar experiment with $sarsa" in {
+    val policy = learnAndLog (sarsa)
+  }

--- a/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
@@ -2,19 +2,19 @@ package symsim
 package examples.concrete.windygrid
 
 class Experiments
-   extends ExperimentSpec[GridState, GridObservableState, GridAction.Value]:
+  extends ExperimentSpec[GridState, GridObservableState, GridAction.Value]:
 
-   // Import evidence that states and actions can be enumerated
-   import WindyGrid._
+  // Import evidence that states and actions can be enumerated
+  import WindyGrid.*
 
-   val sarsa = symsim.concrete.ConcreteSarsa (
-     agent = WindyGrid,
-     alpha = 0.1,
-     gamma = 0.1,
-     epsilon = 0.1,
-     episodes = 0
-   )
+  val sarsa = symsim.concrete.ConcreteSarsa (
+    agent = WindyGrid,
+    alpha = 0.1,
+    gamma = 0.1,
+    epsilon = 0.1,
+    episodes = 0
+  )
 
-   s"WindyGrid experiment with $sarsa" in {
-     val policy = learnAndLog (sarsa)
-   }
+  s"WindyGrid experiment with $sarsa" in {
+    val policy = learnAndLog (sarsa)
+  }


### PR DESCRIPTION
These are purely syntactic changes - aimed at moving to a newer Scala, which might help with the cost of `for-yield` as per https://github.com/oleg-py/better-monadic-for (not too optimistic, but a version bump is always a good thing anyway).