### PR TITLE
Tail-recursion problems in initialization of state for example agents

### DIFF
--- a/src/main/scala/symsim/examples/concrete/breaking/Car.scala
+++ b/src/main/scala/symsim/examples/concrete/breaking/Car.scala
@@ -71,7 +71,7 @@ object Car
 
     def initialize: Randomized[CarState] = for
       v <- Randomized.repeat (Randomized.between (0.0, 10.0))
-      p <- Randomized.repeat (Randomized.between (0.0, 15.0))
+      p <- Randomized.between (0.0, 15.0)
       s = CarState (v, p) if !isFinal (s)
     yield s
 

--- a/src/main/scala/symsim/examples/concrete/breaking/Car.scala
+++ b/src/main/scala/symsim/examples/concrete/breaking/Car.scala
@@ -72,9 +72,7 @@ object Car
     def initialize: Randomized[CarState] = for
       v <- Randomized.repeat (Randomized.between (0.0, 10.0))
       p <- Randomized.repeat (Randomized.between (0.0, 15.0))
-      s0 = CarState (v,p)
-      s <- if isFinal (s0) then initialize
-           else Randomized.const (s0)
+      s = CarState (v, p) if !isFinal (s)
     yield s
 
 end Car

--- a/src/main/scala/symsim/examples/concrete/mountaincar/MountainCar.scala
+++ b/src/main/scala/symsim/examples/concrete/mountaincar/MountainCar.scala
@@ -76,8 +76,7 @@ object MountainCar
   def initialize: Randomized[CarState] = for
     p <- Randomized.repeat (Randomized.between (-1.2, 0.5))
     v <- Randomized.repeat (Randomized.between (-1.5, 1.5))
-    s0 = CarState (v, p)
-    s <- if isFinal (s0) then initialize else Randomized.const (s0)
+    s = CarState (v, p) if !isFinal (s) 
   yield s
 
   override def zeroReward: CarReward = 0.0

--- a/src/main/scala/symsim/examples/concrete/simplemaze/project/build.properties
+++ b/src/main/scala/symsim/examples/concrete/simplemaze/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.4.9

--- a/src/main/scala/symsim/examples/concrete/windygrid/WindyGrid.scala
+++ b/src/main/scala/symsim/examples/concrete/windygrid/WindyGrid.scala
@@ -69,8 +69,7 @@ object WindyGrid
     def initialize: Randomized[GridState] = for
        x <- Randomized.repeat (Randomized.between (1, 11))
        y <- Randomized.repeat (Randomized.between (1, 8))
-       s0 = GridState (x, y)
-       s <- if isFinal (s0) then initialize else Randomized.const (s0)
+       s = GridState (x, y) if !isFinal (s)
     yield s
 
     override def zeroReward: GridReward = 0

--- a/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/Experiments.scala
@@ -12,7 +12,7 @@ class Experiments
      alpha = 0.1,
      gamma = 0.1,
      epsilon = 0.05,
-     episodes = 10000,
+     episodes = 100000,
   )
 
   s"Breaking Car experiment with $sarsa" in {

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -9,7 +9,7 @@ class Experiments
      alpha = 0.1,
      gamma = 0.9,
      epsilon = 0.05,
-     episodes = 70000,
+     episodes = 140000,
    )
 
    s"SimpleMaze experiment with ${sarsa}" in {

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -7,7 +7,7 @@ class Experiments
    val sarsa = symsim.concrete.ConcreteSarsa (
      agent = Maze,
      alpha = 0.1,
-     gamma = 1.0,
+     gamma = 0.9,
      epsilon = 0.05,
      episodes = 70000,
    )


### PR DESCRIPTION
For Car, MountainCar, and WindyGrid I remove the recursion. SimpleMaze already had it right (!!!), I just improve the formulation to be more readable (and then could not resist to fix indentation in the entire class).

Note that the Car in `main` already has the weaker `isFinal` (as I have merged this small change by mistake, while doing the upgrade to Scala 3.1.3). So on this branch we already run experiments with the new finality condition for the breaking car. With these fixes, I was able to run up to 1 million episodes on the breaking car without a stack overflow (but the sbt heap got polluted, and the second experiment has run out of heap space; for half a million the heap space problems seem not to appear; in any case they are independent). 