### PR TITLE
Test that breaking does not move the car backwards

### DIFF
--- a/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
@@ -27,13 +27,19 @@ class CarSpec
 
     // Tests
 
-    "The car cannot move backwards" in check {
+    "A stopped car cannot move, however much you break" in check {
       forAll (positions, actions) { (p, a) =>
         val (s1, r) = Car.step (CarState (v = 0.0, p = p)) (a).head
-        (a <= 0) ==> (s1.p >= p)
+        (a <= 0) ==> (s1.p == p)
       }
     }
 
+    "The car cannot move backwards by breaking" in check {
+      forAll (velocities, positions, actions) { (v, p, a) =>
+        val (s1, r) = Car.step (CarState (v, p = p)) (a).head
+        (v != 0) ==> (s1.p >= p)
+      }
+    }
 
     "Position never becomes negative" in check {
       forAll (velocities, positions, actions) { (v, p, a) =>

--- a/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
@@ -30,7 +30,7 @@ class CarSpec
     "A stopped car cannot move, however much you break" in check {
       forAll (positions, actions) { (p, a) =>
         val (s1, r) = Car.step (CarState (v = 0.0, p = p)) (a).head
-        (a <= 0) ==> (s1.p == p)
+        s1.p == p
       }
     }
 


### PR DESCRIPTION
Two changes:

* Change an old test (which tested that breaking in a stopped car cannot move the car backwards) to testing that breaking in a stopped car cannot move the car at all
* Add a test that if the car velocity is non-zero, then we move forward.