### PR TITLE
Remove the `head` calls from `CarSpec` tests (representation leakage)

### DIFF
--- a/src/main/scala/symsim/concrete/Randomized.scala
+++ b/src/main/scala/symsim/concrete/Randomized.scala
@@ -1,5 +1,7 @@
 package symsim.concrete
 
+import scala.annotation.targetName
+
 import cats.data.State
 import org.scalacheck.{Gen, Prop}
 
@@ -76,6 +78,7 @@ object Randomized:
    given canTestInRandomized: symsim.CanTestIn[Randomized] =
       new symsim.CanTestIn[Randomized] {
 
+         @targetName ("toPropBoolean")
          def toProp (rProp: Randomized[Boolean]) =
             Prop.forAllNoShrink (toGen (rProp)) (identity[Boolean])
 

--- a/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
@@ -30,40 +30,42 @@ class CarSpec
 
     "A stopped car cannot move, however much you break" in check {
       forAll (positions, actions) { (p, a) =>
-        val (s1, r) = Car.step (CarState (v = 0.0, p = p)) (a).head
-        s1.p == p
+        for (s1, r) <- Car.step (CarState (v = 0.0, p = p)) (a)
+        yield s1.p == p
       }
     }
 
     "The car cannot move backwards by breaking" in check {
       forAll (velocities, positions, actions) { (v, p, a) =>
-        for (s1, r) <- Car.step (CarState (v, p = p)) (a) 
+        for (s1, r) <- Car.step (CarState (v, p = p)) (a)
         yield (v != 0 ==> s1.p >= p)
       }
     }
 
     "Position never becomes negative" in check {
       forAll (velocities, positions, actions) { (v, p, a) =>
-        val (s1, r) = Car.step (CarState (v = v, p = p)) (a).head
-        s1.p >= 0.0
+        for (s1, r) <- Car.step (CarState (v = v, p = p)) (a)
+        yield s1.p >= 0.0
       }
     }
 
 
     "Reward is valid 1" in check {
       forAll  (positions, positions, velocities, actions) { (p1, p2, v, a) =>
-        val r1 = Car.step (CarState (v = v, p = p1)) (a).head._2
-        val r2 = Car.step (CarState (v = v, p = p2)) (a).head._2
-        p1 <= p2 ==> r1 >= r2
+        for
+          (_, r1) <- Car.step (CarState (v = v, p = p1)) (a)
+          (_, r2) <- Car.step (CarState (v = v, p = p2)) (a)
+        yield p1 <= p2 ==> r1 >= r2
       }
     }
 
 
     "Reward is valid 2" in check {
       forAll  (velocities, velocities, positions, actions) { (v1, v2, p, a) =>
-        val r1 = Car.step (CarState (v1, p)) (a).head._2
-        val r2 = Car.step (CarState (v2, p)) (a).head._2
-        v1 <= v2 ==> r1 >= r2
+        for
+          (_, r1) <- Car.step (CarState (v1, p)) (a)
+          (_, r2) <- Car.step (CarState (v2, p)) (a)
+        yield v1 <= v2 ==> r1 >= r2
       }
     }
 

--- a/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
@@ -1,7 +1,8 @@
 package symsim
 package examples.concrete.breaking
 
-import CanTestIn.*
+import symsim.concrete.Randomized.given
+import CanTestIn.given
 
 import org.scalatest.*
 import prop.*
@@ -36,8 +37,8 @@ class CarSpec
 
     "The car cannot move backwards by breaking" in check {
       forAll (velocities, positions, actions) { (v, p, a) =>
-        val (s1, r) = Car.step (CarState (v, p = p)) (a).head
-        (v != 0) ==> (s1.p >= p)
+        for (s1, r) <- Car.step (CarState (v, p = p)) (a) 
+        yield v != 0 ==> s1.p >= p
       }
     }
 

--- a/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/breaking/CarSpec.scala
@@ -38,7 +38,7 @@ class CarSpec
     "The car cannot move backwards by breaking" in check {
       forAll (velocities, positions, actions) { (v, p, a) =>
         for (s1, r) <- Car.step (CarState (v, p = p)) (a) 
-        yield v != 0 ==> s1.p >= p
+        yield (v != 0 ==> s1.p >= p)
       }
     }
 


### PR DESCRIPTION
".head" has been eliminated for tests in this commit.