### PR TITLE
A lazy representation of the Q-Table

### DIFF
--- a/src/main/scala/symsim/QLearning.scala
+++ b/src/main/scala/symsim/QLearning.scala
@@ -33,6 +33,6 @@ trait QLearning[State, ObservableState, Action, Reward, Scheduler[_]]
       correction = r_tt + gamma * q (ds_tt, a_tt) - old_entry
       qval = old_entry + alpha * correction
 
-      q1 = q.updated ((ds_t, a_t), qval)
+      q1 = q.updated (ds_t, a_t, qval)
       a_tt1 <- chooseAction (q1) (ds_tt)
     yield (q1, s_tt, a_tt1)

--- a/src/main/scala/symsim/QLearning.scala
+++ b/src/main/scala/symsim/QLearning.scala
@@ -29,10 +29,10 @@ trait QLearning[State, ObservableState, Action, Reward, Scheduler[_]]
       
       // Q-learning is off-policy (p.844 in Russel & Norvig)
       a_tt = bestAction (q) (ds_tt)
-      old_entry = q (ds_t) (a_t)
-      correction = r_tt + gamma * q (ds_tt) (a_tt) - old_entry
+      old_entry = q (ds_t, a_t)
+      correction = r_tt + gamma * q (ds_tt, a_tt) - old_entry
       qval = old_entry + alpha * correction
 
-      q1 = q + (ds_t -> (q (ds_t) + (a_t -> qval)))
+      q1 = q.updated ((ds_t, a_t), qval)
       a_tt1 <- chooseAction (q1) (ds_tt)
     yield (q1, s_tt, a_tt1)

--- a/src/main/scala/symsim/QTable.scala
+++ b/src/main/scala/symsim/QTable.scala
@@ -18,13 +18,14 @@ trait QTable[State, ObservableState, Action, Reward, Scheduler[_]]
   import agent.instances.*
   import agent.instances.given
 
-  opaque type Q = Map[(ObservableState, Action), Reward]
+  type Key = (ObservableState, Action)
+  opaque type Q = Map[Key, Reward]
   type VF = Q
 
   extension (q: Q) 
     def apply (s: ObservableState, a: Action): Reward = 
       q.getOrElse ((s, a), agent.zeroReward)
-    def updated: ((ObservableState, Action), Reward) => Q = q.updated
+    def updated: (Key, Reward) => Q = q.updated
 
 
   /** Construct a zero initialized Q matrix */

--- a/src/main/scala/symsim/QTable.scala
+++ b/src/main/scala/symsim/QTable.scala
@@ -22,9 +22,9 @@ trait QTable[State, ObservableState, Action, Reward, Scheduler[_]]
   type VF = Q
 
   extension (q: Q) 
-    inline def apply (s: ObservableState, a: Action): Reward = 
-      q.getOrElse (s -> a, agent.zeroReward)
-    inline def updated = q.updated
+    def apply (s: ObservableState, a: Action): Reward = 
+      q.getOrElse ((s, a), agent.zeroReward)
+    def updated: ((ObservableState, Action), Reward) => Q = q.updated
 
 
   /** Construct a zero initialized Q matrix */

--- a/src/main/scala/symsim/QTable.scala
+++ b/src/main/scala/symsim/QTable.scala
@@ -22,11 +22,33 @@ trait QTable[State, ObservableState, Action, Reward, Scheduler[_]]
   type VF = Q
 
   extension (q: Q) 
+
+    /** Allowing to access q(s, a) */
     def apply (s: ObservableState, a: Action): Reward = 
-      q.getOrElse (s, Map[Action, Reward]()).getOrElse (a, agent.zeroReward)
+      q.getOrElse (s, Map[Action, Reward] ())
+       .getOrElse (a, agent.zeroReward)
+
+    /** A copy of the Q-Table with a new entry for (s, a) */
     def updated (s: ObservableState, a: Action, v: Reward): Q = 
       q.updated (s, (q.getOrElse (s, Map ()).updated (a, v))) 
-    private /* TODO? */ def actionValues (s: ObservableState): Map[Action, Reward] = q (s)
+
+    /** An action-value map for a given state.
+      * 
+      * For the time being throws NoSuchElement exception if the state 
+      * is not known to this Q table yet. This can be easily fixed if 
+      * needed.
+      */
+    def actionValues (s: ObservableState): Map[Action, Reward] = 
+      q.getOrElse (s, Map[Action, Reward] ())
+
+    /** States explored and represented in this Q-table so far */
+    def states: List[ObservableState] = q.keys.toList
+
+    /** All actions seen by this Q-table */
+    def actions: Set[Action] = 
+      q.values
+       .flatMap { _.keys }
+       .toSet
 
 
   /** Construct a zero initialized Q matrix */

--- a/src/main/scala/symsim/Sarsa.scala
+++ b/src/main/scala/symsim/Sarsa.scala
@@ -28,9 +28,9 @@ trait Sarsa[State, ObservableState, Action, Reward, Scheduler[_]]
 
          ds_t = agent.observe (s_t)
          ds_tt = agent.observe (s_tt)
-         old_entry = q (ds_t) (a_t)
-         correction = r_tt + gamma * q (ds_tt) (a_tt) - old_entry
+         old_entry = q (ds_t, a_t)
+         correction = r_tt + gamma * q (ds_tt, a_tt) - old_entry
          qval = old_entry + alpha * correction
 
-         q1 = q + (ds_t -> (q (ds_t) + (a_t -> qval)))
+         q1 = q.updated ((ds_t, a_t), qval)
       yield (q1, s_tt, a_tt)

--- a/src/main/scala/symsim/Sarsa.scala
+++ b/src/main/scala/symsim/Sarsa.scala
@@ -32,5 +32,5 @@ trait Sarsa[State, ObservableState, Action, Reward, Scheduler[_]]
          correction = r_tt + gamma * q (ds_tt, a_tt) - old_entry
          qval = old_entry + alpha * correction
 
-         q1 = q.updated ((ds_t, a_t), qval)
+         q1 = q.updated (ds_t, a_t, qval)
       yield (q1, s_tt, a_tt)

--- a/src/main/scala/symsim/concrete/ConcreteQTable.scala
+++ b/src/main/scala/symsim/concrete/ConcreteQTable.scala
@@ -13,7 +13,9 @@ trait ConcreteQTable[State, ObservableState, Action]
 
   def bestAction (q: Q) (s: ObservableState): Action =
     val qs = q.actionValues (s).map { _.swap }
-    qs (qs.keys.max)
+    if qs.isEmpty 
+      then agent.instances.allActions.head
+      else qs (qs.keys.max)
 
 
   def chooseAction (q: Q) (s: ObservableState): Randomized[Action] =

--- a/src/main/scala/symsim/concrete/ConcreteQTable.scala
+++ b/src/main/scala/symsim/concrete/ConcreteQTable.scala
@@ -44,19 +44,20 @@ trait ConcreteQTable[State, ObservableState, Action]
 
   /** We assume that all values define the same set of actions valuations.  */
   def pp_Q (q: Q): Doc =
-    val headings = "" ::q
-      .actions
+    val actions = q.actions.toList.sortBy { _.toString }
+    val headings = "" :: actions
       .map { _.toString }
-      .toList
       .sorted
-    def fmt (s: ObservableState, m: Map[Action, Double]): List[String] =
+    def fmt (s: ObservableState, m: List[Double]): List[String] =
       s.toString ::m
-        .toList
-        .sortBy { _._1.toString }
-        .map { _._2.toString.take (7).padTo (7,'0') }
+        .map { _.toString.take (7).padTo (7, '0') }
     val rows = q
-        .states
-        .map { s => (s, q.actionValues (s)) }
-        .sortBy { _._1.toString }
-        .map (fmt)
-    symsim.tabulate (' ', " | ", headings ::rows, "-".some, "-+-".some)
+      .states
+      .sortBy { _.toString }
+      .map { s => (s, actions.map { q (s, _) }) }
+      .map (fmt)
+    assert (headings.nonEmpty)
+    if rows.nonEmpty then
+      symsim.tabulate (' ', " | ", headings ::rows, "-".some, "-+-".some)
+    else 
+      Doc.text ("The lazy Q table does not contain any states")

--- a/src/main/scala/symsim/concrete/ConcreteQTable.scala
+++ b/src/main/scala/symsim/concrete/ConcreteQTable.scala
@@ -12,7 +12,7 @@ trait ConcreteQTable[State, ObservableState, Action]
   import agent.instances.*
 
   def bestAction (q: Q) (s: ObservableState): Action =
-    val qs = q (s).map { _.swap }
+    val qs = q.actionValues (s).map { _.swap }
     qs (qs.keys.max)
 
 

--- a/src/main/scala/symsim/concrete/Randomized.scala
+++ b/src/main/scala/symsim/concrete/Randomized.scala
@@ -66,6 +66,9 @@ object Randomized:
       between (0, choices.size)
          .map { i => choices (i) }
 
+   def eachOf[A] (choices: A*): Randomized[A] = 
+     LazyList(choices*)
+
    def repeat[A] (ra: =>Randomized[A]): Randomized[A] =
       LazyList.continually (ra).flatten
 

--- a/src/main/scala/symsim/examples/concrete/windygrid/WindyGrid.scala
+++ b/src/main/scala/symsim/examples/concrete/windygrid/WindyGrid.scala
@@ -15,66 +15,62 @@ case class GridState (x: Int, y: Int):
 type GridObservableState = GridState
 type GridReward = Double
 
-object GridAction extends Enumeration:
-   type GridAction = Value
-   val R, L, U, D = Value
+enum GridAction: 
+  case R, L, U, D
 
 
-object WindyGrid
-  extends Agent[GridState, GridObservableState, GridAction, GridReward, Randomized]:
+object WindyGrid extends 
+  Agent[GridState, GridObservableState, GridAction, GridReward, Randomized]:
 
-    val windspec = Array (0, 0, 0, 1, 1, 1, 2, 2, 1, 0)
+  val WindSpec = Array (0, 0, 0, 1, 1, 1, 2, 2, 1, 0)
 
-    def isFinal (s: GridState): Boolean =
-      (s.x, s.y) == (8, 4)
+  def isFinal (s: GridState): Boolean =
+    (s.x, s.y) == (8, 4)
 
-    def observe (s: GridState): GridObservableState =
-      GridState (s.x, s.y)
+  def observe (s: GridState): GridObservableState =
+    GridState (s.x, s.y)
 
+  def gridReward (s: GridState) (a: GridAction): GridReward = s match
+    case GridState (8, 4) => 0.0   // final state
+    case GridState (_, _) => -1.0
 
+  def stepRight (s: GridState): GridState =
+    val x1 = (s.x + 1) min 10
+    val y1 = (s.y+WindSpec(s.x-1)) min 7
+    GridState (x1, y1)
 
-    def GridReward (s: GridState) (a: GridAction): GridReward = s match
-       case GridState (8, 4) => 0.0   // final state
-       case GridState (_, _) => -1.0
+  def stepLeft (s: GridState): GridState =
+    val x1 = (s.x - 1) max 1
+    val y1 = (s.y + WindSpec (s.x - 1)) min 7
+    GridState (x1, y1)
 
+  def stepUp (s: GridState): GridState =
+    val x1 = s.x
+    val y1 = (s.y + 1 + WindSpec (s.x - 1)) min 7
+    GridState (x1, y1)
 
-    def stepRight (s: GridState): GridState =
-       val x1 = (s.x + 1) min 10
-       val y1 = (s.y+windspec(s.x-1)) min 7
-       GridState (x1, y1)
+  def stepDown (s: GridState): GridState =
+    val x1 = s.x
+    val y1 = ((s.y - 1 + WindSpec (s.x - 1)) max 1) min 7
+    GridState (x1, y1)
 
-    def stepLeft (s: GridState): GridState =
-       val x1 = (s.x - 1) max 1
-       val y1 = (s.y + windspec (s.x - 1)) min 7
-       GridState (x1, y1)
+  def step (s: GridState) (a: GridAction): Randomized[(GridState, GridReward)] =
+    val s1 = a match
+      case GridAction.R => stepRight (s)
+      case GridAction.L => stepLeft (s)
+      case GridAction.U => stepUp (s)
+      case GridAction.D => stepDown (s)
+    Randomized.const (s1 -> gridReward (s1) (a))
 
-    def stepUp (s: GridState): GridState =
-       val x1 = s.x
-       val y1 = (s.y + 1 + windspec (s.x - 1)) min 7
-       GridState (x1, y1)
+  def initialize: Randomized[GridState] = for
+    x <- Randomized.repeat (Randomized.between (1, 11))
+    y <- Randomized.repeat (Randomized.between (1, 8))
+    s = GridState (x, y) if !isFinal (s)
+  yield s
 
-    def stepDown (s: GridState): GridState =
-       val x1 = s.x
-       val y1 = ((s.y - 1 + windspec (s.x - 1)) max 1) min 7
-       GridState (x1, y1)
+  override def zeroReward: GridReward = 0
 
-    def step (s: GridState) (a: GridAction): Randomized[(GridState, GridReward)] =
-       val s1 = a match
-          case R => stepRight (s)
-          case L => stepLeft (s)
-          case U => stepUp (s)
-          case D => stepDown (s)
-       Randomized.const (s1 -> GridReward (s1) (a))
-
-    def initialize: Randomized[GridState] = for
-       x <- Randomized.repeat (Randomized.between (1, 11))
-       y <- Randomized.repeat (Randomized.between (1, 8))
-       s = GridState (x, y) if !isFinal (s)
-    yield s
-
-    override def zeroReward: GridReward = 0
-
-    val instances = WindyGridInstances
+  val instances = WindyGridInstances
 
 end WindyGrid
 
@@ -82,18 +78,18 @@ end WindyGrid
   * needs to be able to do to work in the framework.
   */
 object WindyGridInstances
-  extends AgentConstraints[GridState, GridObservableState, GridAction, GridReward, Randomized]:
+  extends AgentConstraints[GridState, GridObservableState, GridAction, 
+    GridReward, Randomized]:
 
   given enumAction: BoundedEnumerable[GridAction] =
     BoundedEnumerableFromList (U, L, R, D)
 
   given enumState: BoundedEnumerable[GridObservableState] =
-     val ss = for
-         x <- Seq (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-         y <- Seq (1, 2, 3, 4, 5, 6, 7)
-     yield GridState (x, y)
-     BoundedEnumerableFromList (ss*)
-
+    val ss = for
+      x <- Seq (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+      y <- Seq (1, 2, 3, 4, 5, 6, 7)
+    yield GridState (x, y)
+    BoundedEnumerableFromList (ss*)
 
   given schedulerIsMonad: Monad[Randomized] = Randomized.randomizedIsMonad
 
@@ -102,8 +98,8 @@ object WindyGridInstances
   given canTestInScheduler: CanTestIn[Randomized] = Randomized.canTestInRandomized
 
   lazy val genGridState: Gen[GridState] = for
-     x <- Gen.choose (1, 10)
-     y <- Gen.choose (1, 7)
+    x <- Gen.choose (1, 10)
+    y <- Gen.choose (1, 7)
   yield GridState (x, y)
 
   given arbitraryState: Arbitrary[GridState] = Arbitrary (genGridState)

--- a/src/main/scala/symsim/laws/SarsaLaws.scala
+++ b/src/main/scala/symsim/laws/SarsaLaws.scala
@@ -34,7 +34,7 @@ case class SarsaLaws[State, ObservableState, Action, Reward, Scheduler[_]]
    import sarsa.agent.instances.given
 
    def isStateTotal (q: sarsa.Q): Boolean =
-     q.states == sarsa.agent.instances.allObservableStates.toSet
+     q.states.toSet == sarsa.agent.instances.allObservableStates.toSet
 
    def isActionTotal (q: sarsa.Q): Boolean =
      q.states.forall { s =>

--- a/src/test/scala/symsim/ExperimentSpec.scala
+++ b/src/test/scala/symsim/ExperimentSpec.scala
@@ -10,16 +10,15 @@ trait ExperimentSpec[State, ObservableState, Action]
   org.scalatest.matchers.should.Matchers:
 
    def learnAndLog (setup: concrete.ConcreteExactRL[State, ObservableState, Action]
-     with ConcreteQTable[State, ObservableState, Action],
+                             & ConcreteQTable[State, ObservableState, Action],
      outputQTable: Boolean = true,
      outputPolicy: Boolean = true, 
-     outputToFile: Option[String] = None) =
+     outputToFile: Option[String] = None): setup.Policy =
 
      val q = setup.runQ
      val policy = setup.qToPolicy (q)
      val policyOutput = setup.pp_policy (policy)
      val qOutput = setup.pp_Q (q)
-
 
      outputToFile match
      case None => 

--- a/src/test/scala/symsim/concrete/ConcreteSarsaSpec.scala
+++ b/src/test/scala/symsim/concrete/ConcreteSarsaSpec.scala
@@ -34,7 +34,7 @@ class ConcreteSarsaSpec
 
 
   "initQ terminates, no stack overflow (regression)"  in {
-    sarsa.initialize.head
+    sarsa.initialize
   }
 
   // this test does not really prove the tail recursiveness,

--- a/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
+++ b/src/test/scala/symsim/concrete/UnitAgentExperimentsSpec.scala
@@ -16,7 +16,8 @@ class UnitAgentExperiments
   )
 
   s"UnitAgent test run with $sarsa (should not crash)" in {
-     learnAndLog (sarsa) should be (List (() -> ()).toMap)
+    val p: sarsa.Policy = learnAndLog (sarsa) 
+    (p.isEmpty || p (()) == ()) should be (true)
   }
 
   val qLearning = symsim.concrete.ConcreteQLearning (
@@ -28,5 +29,6 @@ class UnitAgentExperiments
   )
 
   s"UnitAgent test run with $qLearning (should not crash)" in {
-      learnAndLog (qLearning) should be (List (() -> ()).toMap)
+    val p: qLearning.Policy = learnAndLog (qLearning) 
+    (p.isEmpty || p (()) == ()) should be (true)
   }

--- a/src/test/scala/symsim/examples/concrete/golf/GolfSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/golf/GolfSpec.scala
@@ -32,7 +32,7 @@ class GolfSpec
   property ("Q-table values are non-positive") =
     forAll { (s: GolfState, a: GolfAction) =>
       for Q <- sarsa.learningEpisode (sarsa.initialize, s)
-      yield Q (s) (a) <= 0
+      yield Q (s, a) <= 0
     }
 
   property ("Using club D in the sand is the best trained action") =

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -7,7 +7,7 @@ class Experiments
    val sarsa = symsim.concrete.ConcreteSarsa (
      agent = Maze,
      alpha = 0.1,
-     gamma = 0.5,
+     gamma = 1,
      epsilon = 0.05,
      episodes = 140000,
    )

--- a/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/Experiments.scala
@@ -7,7 +7,7 @@ class Experiments
    val sarsa = symsim.concrete.ConcreteSarsa (
      agent = Maze,
      alpha = 0.1,
-     gamma = 1,
+     gamma = 0.5,
      epsilon = 0.05,
      episodes = 140000,
    )

--- a/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
@@ -2,7 +2,7 @@ package symsim
 package examples.concrete.windygrid
 
 class Experiments
-  extends ExperimentSpec[GridState, GridObservableState, GridAction.Value]:
+  extends ExperimentSpec[GridState, GridObservableState, GridAction]:
 
   // Import evidence that states and actions can be enumerated
   import WindyGrid.*

--- a/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
+++ b/src/test/scala/symsim/examples/concrete/windygrid/Experiments.scala
@@ -12,7 +12,7 @@ class Experiments
     alpha = 0.1,
     gamma = 0.1,
     epsilon = 0.1,
-    episodes = 0
+    episodes = 10000
   )
 
   s"WindyGrid experiment with $sarsa" in {

--- a/src/test/scala/symsim/examples/concrete/windygrid/WindyGridSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/windygrid/WindyGridSpec.scala
@@ -17,15 +17,16 @@ class WindyGridSpec
   import WindyGrid.instances.{arbitraryAction, arbitraryState}
 
   property ("Up and Down will never affect the x value") =
-    forAll { (s: GridState) => for
+    forAll { (s: GridState) => 
+      for
         (s1, r) <- WindyGrid.step (s) (GridAction.U)
         (s2, r) <- WindyGrid.step (s) (GridAction.D)
       yield s1._1 == s.x && s2._1 == s.x
     }
 
   property ("If wind, R affects both x and y unless in the y's upper bound") =
-    forAll { (s: GridState) => for 
-      (s1, r) <- WindyGrid.step (s) (GridAction.R)
+    forAll { (s: GridState) => 
+      for (s1, r) <- WindyGrid.step (s) (GridAction.R)
       yield (s.x >= 4 && s.x <= 8 && s.y <= 6) ==> (s1._1 != s.x && s1._2 != s.y)
     }
 
@@ -35,8 +36,10 @@ class WindyGridSpec
       yield (s.x >= 4 && s.x <= 8 && s.y <= 6) ==> (s1._1 != s.x && s1._2 != s.y)
     }
 
+  // The test runs 1 episode regardless the last argument value (`episodes`)
+  val sarsa = ConcreteSarsa (WindyGrid, 0.1, 0.5, 0.1, 1)
+
   property ("Q-table values are non-positive") =
-    val sarsa = ConcreteSarsa (WindyGrid, 0.1, 0.5, 0.1, 100)
     forAll { (s: GridState, a: GridAction) =>
       for Q <- sarsa.learningEpisode (sarsa.initialize, s)
       yield Q (s, a) <= 0


### PR DESCRIPTION
This changes the representation of the Q-Table to assume zero as the default reward, and to store only entries that have been updated.  This should improve memory use for state spaces that store quite large states.

I tested a bit on mountaincar, and the outcome is not overwhelming. The new representations seems about 30% faster (on 300K episodes), but otherwise it is not able to explore more episodes than the old one.

@mohsen-ghaffari1992, could you test this branch a bit more? Check how it behaves on other examples, and whether it trains the same policies? (the printing code had to be changed, so now it might print wrong policies).  