### PR TITLE
Cleanup use of test generators in spec files

### DIFF
--- a/src/main/scala/symsim/examples/concrete/braking/Car.scala
+++ b/src/main/scala/symsim/examples/concrete/braking/Car.scala
@@ -112,8 +112,8 @@ object CarInstances
     concrete.Randomized.canTestInRandomized
 
   lazy val genCarState: Gen[CarState] = for
-     v <- Gen.choose (0.0, Double.MaxValue)
-     p <- Gen.choose (0.0, Double.MaxValue)
+     v <- Gen.choose (0.0, 10.0)
+     p <- Gen.choose (0.0, 10.0)
   yield CarState (v, p)
 
   given arbitraryState: Arbitrary[CarState] = Arbitrary (genCarState)

--- a/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
+++ b/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
@@ -35,6 +35,11 @@ import symsim.concrete.Randomized
  */
 
 type MazeState = (Int,Int)
+
+extension (s: MazeState)
+  inline def x: Int = s._1
+  inline def y: Int = s._2
+
 type MazeObservableState = MazeState
 type MazeReward = Double
 

--- a/src/test/scala/symsim/concrete/RandomizedSpec.scala
+++ b/src/test/scala/symsim/concrete/RandomizedSpec.scala
@@ -104,36 +104,35 @@ class RandomizedSpec
      * the current implementation of Randomized.
      */
     "Randomized is referentially transparent (failing)" ignore {
-        assert (
-           Randomized.repeat (Randomized.between(1,100)).take (10).toList ==
-           Randomized.repeat (Randomized.between(1,100)).take (10).toList
-        )
+      assert (
+        Randomized.repeat (Randomized.between(1,100)).take (10).toList ==
+        Randomized.repeat (Randomized.between(1,100)).take (10).toList
+      )
     }
 
     "Randomized.gaussian (m, d) has stddev 'd' and mean 'm'" in check {
 
-       val n = 10000
-       val epsilon = 0.05
+      val n = 20000
+      val epsilon = 0.06
 
-       forAllNoShrink (Gen.choose (-100.0, +100.0), Gen.choose(0.001,+3.0)) {
-          (m: Double, d: Double) =>
-             val sample = Randomized.repeat (Randomized.gaussian (mean = m, stddev = d)).take (n)
-             val mean = sample.sum / n
-             val variance = sample.map { x => (x-mean)*(x-mean) }.sum / n
-             ("Mean"   |: Math.abs (mean/m - 1.0) <= epsilon) &&
-             ("StdDev" |: Math.abs (Math.sqrt (variance)/d - 1.0) <= epsilon)
-       }
+      forAllNoShrink (Gen.choose (-100.0, +100.0), Gen.choose(0.001,+3.0)) {
+        (m: Double, d: Double) =>
+          val sample = Randomized.repeat (Randomized.gaussian (mean = m, stddev = d)).take (n)
+          val mean = sample.sum / n
+          val variance = sample.map { x => (x-mean)*(x-mean) }.sum / n
+          ("Mean"   |: Math.abs (mean/m - 1.0) <= epsilon) &&
+          ("StdDev" |: Math.abs (Math.sqrt (variance)/d - 1.0) <= epsilon)
+      }
     }
-
   }
 
   "Randomized Foldable Instance" - {
 
     "check that foldLeft works (sum)" in {
-       val r = Randomized.repeat (Randomized.oneOf (1)).take (C)
-       val sum = Randomized.randomizedIsFoldable
-          .foldLeft[Int, Int] (r, 0) { _ + _ }
-       assert (sum == C)
+      val r = Randomized.repeat (Randomized.oneOf (1)).take (C)
+      val sum = Randomized.randomizedIsFoldable
+        .foldLeft[Int, Int] (r, 0) { _ + _ }
+      assert (sum == C)
     }
   }
 

--- a/src/test/scala/symsim/examples/concrete/braking/CarSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/braking/CarSpec.scala
@@ -1,68 +1,52 @@
 package symsim
 package examples.concrete.braking
 
-import symsim.concrete.Randomized.given
-import CanTestIn.given
-
-import org.scalatest.*
-import prop.*
-import org.scalacheck.Arbitrary.*
 import org.scalacheck.Gen
-import org.scalatest.prop.Whenever
-import org.scalatest.*
-import org.scalacheck.Prop.{forAll, forAllNoShrink, propBoolean, exists}
-import examples.concrete.braking.CarState
-import examples.concrete.braking.Car
+import org.scalacheck.Prop.*
+
+import symsim.CanTestIn.given
+import symsim.concrete.Randomized.given
+
+// To eliminate the warning on CarSpec, until scalacheck makes it open
+import scala.language.adhocExtensions
 
 /** Sanity tests for symsim.concrete.braking */
-class CarSpec
-  extends org.scalatest.freespec.AnyFreeSpec,
-    org.scalatestplus.scalacheck.Checkers:
+object CarSpec
+  extends org.scalacheck.Properties ("braking.Car"):
 
-  given PropertyCheckConfiguration =
-    PropertyCheckConfiguration(minSuccessful = 100)
+  import Car.instances.{arbitraryState, arbitraryAction}
 
-  "Sanity checks for symsim.concrete.braking" - {
-
-    import Car.instances.{arbitraryState, arbitraryAction}
-
-    // Tests
-
-    "A stopped car cannot move, however much you break" in check {
-      forAll { (s: CarState, a: CarAction) =>
-        for (s1, r) <- Car.step (s.copy (v = 0.0)) (a)
-        yield s1.p == s.p
-      }
+  property("A stopped car cannot move, however much you break") = 
+    forAll { (s: CarState, a: CarAction) =>
+      for (s1, r) <- Car.step (s.copy (v = 0.0)) (a)
+      yield s1.p == s.p
     }
 
-    "The car cannot move backwards by braking" in check {
-      forAll { (s: CarState, a: CarAction) =>
-        for (s1, r) <- Car.step (s) (a)
-        yield (s.v != 0 ==> s1.p >= s.p)
-      }
+  property("The car cannot move backwards by braking") = 
+    forAll { (s: CarState, a: CarAction) =>
+      for (s1, r) <- Car.step (s) (a)
+      yield (s.v != 0 ==> s1.p >= s.p)
     }
 
-    "Position never becomes negative" in check {
-      forAll { (s: CarState, a: CarAction) =>
-        for (s1, r) <- Car.step (s) (a)
-        yield s1.p >= 0.0
-      }
+  property("Position never becomes negative") = 
+    forAll { (s: CarState, a: CarAction) =>
+      for (s1, r) <- Car.step (s) (a)
+      yield s1.p >= 0.0 
     }
 
-
-    "Reward is valid 1" in check {
-      forAll  { (s1: CarState, s2: CarState, a: CarAction) => for
+  property("Reward is valid 1") = 
+    forAll  { (s1: CarState, s2: CarState, a: CarAction) => 
+      for
         (_, r1) <- Car.step (CarState (v = s1.v, p = s1.p min s2.p)) (a)
         (_, r2) <- Car.step (CarState (v = s1.v, p = s1.p max s2.p)) (a)
-      yield r1 >= r2
-    } }
+      yield r1 >= r2 
+    }
 
-
-    "Reward is valid 2" in check {
-      forAll { (s1: CarState, s2: CarState, a: CarAction) => for
+  property("Reward is valid 2") = 
+    forAll { (s1: CarState, s2: CarState, a: CarAction) => 
+      for
         (_, r1) <- Car.step (CarState (v = s1.v min s2.v, p = s1.p)) (a)
         (_, r2) <- Car.step (CarState (v = s1.v max s2.v, p = s1.p)) (a)
-      yield r1 >= r2
-    } }
+      yield r1 >= r2 
+    }
 
-  }

--- a/src/test/scala/symsim/examples/concrete/braking/CarSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/braking/CarSpec.scala
@@ -7,14 +7,14 @@ import org.scalacheck.Prop.*
 import symsim.CanTestIn.given
 import symsim.concrete.Randomized.given
 
+import Car.instances.{arbitraryState, arbitraryAction}
+
 // To eliminate the warning on CarSpec, until scalacheck makes it open
 import scala.language.adhocExtensions
 
 /** Sanity tests for symsim.concrete.braking */
 object CarSpec
   extends org.scalacheck.Properties ("braking.Car"):
-
-  import Car.instances.{arbitraryState, arbitraryAction}
 
   property("A stopped car cannot move, however much you break") = 
     forAll { (s: CarState, a: CarAction) =>

--- a/src/test/scala/symsim/examples/concrete/cliffwalking/CliffWalkingSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/cliffwalking/CliffWalkingSpec.scala
@@ -1,33 +1,21 @@
-package symsim
-package examples.concrete.cliffWalking
+package symsim.examples.concrete.cliffWalking
 
-import symsim.concrete.Randomized.given
-import CanTestIn.given
-
-import org.scalacheck.{Arbitrary, Gen, Prop}
-import org.scalacheck.Arbitrary.*
+import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
-import org.scalacheck.Prop.*
-import examples.concrete.cliffWalking.CWState
-import examples.concrete.cliffWalking.CliffWalking
-import symsim.concrete.ConcreteSarsa
-import symsim.concrete.Randomized
 
-// To eliminate the warning on CliffWalkingSpec, until scalacheck makes it open
+import symsim.CanTestIn.given
+import symsim.concrete.Randomized.given
+
+import CliffWalking.instances.{arbitraryState, arbitraryAction}
+
+// Eliminate the warning on CliffWalkingSpec, until scalacheck makes it open
 import scala.language.adhocExtensions
 
-/** Sanity tests for Randomized as a Scheduler */
-class CliffWalkingSpec
-  extends org.scalacheck.Properties ("CliffWalking"):
-
-    // Generators of test data
-    val states = Gen.oneOf (CliffWalking.instances.enumState.membersAscending)
-    val actions = Gen.oneOf (CliffWalking.instances.enumAction.membersAscending)
-
-    // Tests
+object CliffWalkingSpec
+  extends org.scalacheck.Properties ("cliffwalking.CliffWalking"):
 
     property("All rewards are negative") =
-      forAll(states, actions) { (s, a) =>
+      forAll { (s: CWState, a: CWAction) =>
         for (_, r) <- CliffWalking.step (s) (a)
         yield r < 0
       }

--- a/src/test/scala/symsim/examples/concrete/simplemaze/MazeSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/MazeSpec.scala
@@ -11,7 +11,7 @@ import Maze.instances.{arbitraryState, arbitraryAction}
 // Eliminate the warning on MazeSpec, until scalacheck makes Properties open
 import scala.language.adhocExtensions
 
-class MazeSpec
+object MazeSpec
   extends org.scalacheck.Properties ("simplemaze.Maze"):
 
   property ("Agent near to left wall, cannot go left") =

--- a/src/test/scala/symsim/examples/concrete/simplemaze/MazeSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/MazeSpec.scala
@@ -6,47 +6,40 @@ import org.scalacheck.Prop.forAll
 import symsim.CanTestIn.given
 import symsim.concrete.Randomized.given
 
-// To eliminate the warning on Simple maze, until scalacheck makes it open
+import Maze.instances.{arbitraryState, arbitraryAction}
+
+// Eliminate the warning on MazeSpec, until scalacheck makes Properties open
 import scala.language.adhocExtensions
 
 class MazeSpec
-  extends org.scalacheck.Properties ("SimpleMaze"):
-
-  // Generators of test data
-
-  val xs = Gen.oneOf[Int] (1, 2, 3, 4)
-  val ys = Gen.oneOf[Int] (1, 2, 3)
-  val actions = Gen.oneOf (Maze.instances.enumAction.membersAscending)
-  val states = Gen.oneOf (Maze.instances.enumState.membersAscending)
-
-  // Tests
+  extends org.scalacheck.Properties ("simplemaze.Maze"):
 
   property ("Agent near to left wall, cannot go left") =
-    forAll (ys) { y =>
-      for (s1, r) <- Maze.step (1, y) (Left)
+    forAll { (s: MazeState) =>
+      for (s1, r) <- Maze.step (1, s.y) (Left)
       yield s1._1 == 1
     }
 
   property ("Agent near to right wall, cannot go right") =
-    forAll (ys) { y =>
-      for (s1, r) <- Maze.step (4, y) (Right)
+    forAll { (s: MazeState) =>
+      for (s1, r) <- Maze.step (4, s.y) (Right)
       yield s1._1 == 4
     }
 
   property ("Agent near to up wall, cannot go up") =
-    forAll (xs) { x =>
-      for (s1, r) <- Maze.step (x, 3) (Up)
+    forAll { (s: MazeState) =>
+      for (s1, r) <- Maze.step (s.x, 3) (Up)
       yield s1._2 == 3
     }
 
   property ("Agent near to down wall, cannot go down") =
-    forAll (xs) { x =>
-      for (s1, r) <- Maze.step (x, 1) (Down)
+    forAll { (s: MazeState) =>
+      for (s1, r) <- Maze.step (s.x, 1) (Down)
       yield s1._2 == 1
     }
 
   property ("Agent cannot go into block") =
-    forAll (states, actions) { (s, a) =>
+    forAll { (s: MazeState, a: MazeAction) =>
       for (s1, r) <- Maze.step (s) (a)
       yield s1 != (2, 2)
     }

--- a/src/test/scala/symsim/examples/concrete/windygrid/WindyGridSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/windygrid/WindyGridSpec.scala
@@ -8,13 +8,13 @@ import symsim.concrete.ConcreteSarsa
 import symsim.concrete.Randomized
 import symsim.concrete.Randomized.given
 
-// To eliminate the warning on WindyGridSpec, until scalacheck makes it open
+import WindyGrid.instances.{arbitraryAction, arbitraryState}
+
+// Eliminate the warning on WindyGridSpec until scalacheck makes Properties open
 import scala.language.adhocExtensions
 
 object WindyGridSpec
   extends org.scalacheck.Properties ("WindyGrid"):
-
-  import WindyGrid.instances.{arbitraryAction, arbitraryState}
 
   property ("Up and Down will never affect the x value") =
     forAll { (s: GridState) => 

--- a/src/test/scala/symsim/examples/concrete/windygrid/WindyGridSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/windygrid/WindyGridSpec.scala
@@ -1,7 +1,6 @@
 package symsim.examples.concrete.windygrid
 
 import org.scalacheck.Gen
-import org.scalacheck.Prop.forAll
 import org.scalacheck.Prop.*
 
 import symsim.CanTestIn.given
@@ -9,7 +8,7 @@ import symsim.concrete.ConcreteSarsa
 import symsim.concrete.Randomized
 import symsim.concrete.Randomized.given
 
-// To eliminate the warning on WindyGird, until scalacheck makes it open
+// To eliminate the warning on WindyGridSpec, until scalacheck makes it open
 import scala.language.adhocExtensions
 
 object WindyGridSpec


### PR DESCRIPTION
I have went through all the agent tests (Specs) to:

- Remove any custom generators from these files, use the Agent.instances generators instead.
- Clean up imports and package declarations
- Remove few remaining dependencies on scalatest in the agent tests

This should be fairly non-controversial (purely cleanup tasks).