### PR TITLE
Eliminate explicit toProp in AgentLaws

### DIFF
--- a/src/main/scala/symsim/laws/AgentLaws.scala
+++ b/src/main/scala/symsim/laws/AgentLaws.scala
@@ -53,12 +53,11 @@ case class AgentLaws[State, ObservableState, Action, Reward, Scheduler[_]]
     "observe (step (s) (a)._1) ∈ ObservableState" ->
     forAll { (s0: State) =>
       forAll { (a: Action) =>
-        val prop = for
-          s1r <- agent.step (s0) (a)
+        for
+          s1r    <- agent.step (s0) (a)
           (s1, r) = s1r
-          d1 = agent.observe (s1)
+          d1      = agent.observe (s1)
         yield observableStates.contains (d1)
-        prop
     } },
 
     /** Law: The initial state is not a fixed point of the step function. So
@@ -67,8 +66,8 @@ case class AgentLaws[State, ObservableState, Action, Reward, Scheduler[_]]
     "∀ s ∈ initialize ⋅ ∀ a ∈ Actions ⋅ step (s) (a) ≠ (s,_)" ->
     forAll (agent.initialize.toGen) { (s: State) =>
       exists { (a: Action) => 
-        val prop = for sr <- agent.step (s) (a) yield sr._1 != s
-        prop
+        for sr <- agent.step (s) (a) 
+        yield sr._1 != s
     } }
     // When we add non-episodic tasks this should become: there is at least two
     // actions that have a different reward, or at least one that leads to a

--- a/src/main/scala/symsim/laws/AgentLaws.scala
+++ b/src/main/scala/symsim/laws/AgentLaws.scala
@@ -9,6 +9,7 @@ import org.scalacheck.Prop
 import org.scalacheck.Prop.*
 
 import symsim.CanTestIn.*
+import symsim.CanTestIn.given
 
 /** Collect the laws that define correctness of an Agent.  This appears
   * superfluous on top of symsim.law.AgentLaws, but it will become more
@@ -57,7 +58,7 @@ case class AgentLaws[State, ObservableState, Action, Reward, Scheduler[_]]
           (s1, r) = s1r
           d1 = agent.observe (s1)
         yield observableStates.contains (d1)
-        prop.toProp
+        prop
     } },
 
     /** Law: The initial state is not a fixed point of the step function. So
@@ -67,7 +68,7 @@ case class AgentLaws[State, ObservableState, Action, Reward, Scheduler[_]]
     forAll (agent.initialize.toGen) { (s: State) =>
       exists { (a: Action) => 
         val prop = for sr <- agent.step (s) (a) yield sr._1 != s
-        prop.toProp
+        prop
     } }
     // When we add non-episodic tasks this should become: there is at least two
     // actions that have a different reward, or at least one that leads to a


### PR DESCRIPTION
Issue #157 has been solved in this commit. It is just removing `toProp` and adding `import symsim.CanTestIn.given`.