### PR TITLE
Add time limit to simple maze

### DIFF
--- a/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
+++ b/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
@@ -52,10 +52,9 @@ object Maze
     Episodic:
 
   val TimeHorizon: Int = 2000
-  val TimeLimit: Int = 10
 
   def isFinal (s: MazeState): Boolean =
-    (s._1, s._2) == (4, 3) || (s._1, s._2) == (4, 2) || s._3 == 100
+    (s._1, s._2) == (4, 3) || (s._1, s._2) == (4, 2) || s._3 == TimeHorizon
 
   // Maze is discrete
   def observe (s: MazeState): MazeObservableState = (s._1, s._2)

--- a/src/test/scala/symsim/examples/concrete/simplemaze/BdlExperiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/BdlExperiments.scala
@@ -4,7 +4,7 @@ package examples.concrete.simplemaze
 import Maze.instances.given
 
 class BdlExperiments
-   extends ExperimentSpec[MazeState,MazeState,MazeAction]:
+   extends ExperimentSpec[MazeState,MazeObservableState,MazeAction]:
 
    val sarsa = symsim.concrete.BdlConcreteSarsa (
      agent = Maze,

--- a/src/test/scala/symsim/examples/concrete/simplemaze/ExpectedSarsaExperiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/ExpectedSarsaExperiments.scala
@@ -4,7 +4,7 @@ package examples.concrete.simplemaze
 import Maze.instances.given
 
 class ExpectedSarsaExperiments
-   extends ExperimentSpec[MazeState,MazeState,MazeAction]:
+   extends ExperimentSpec[MazeState,MazeObservableState,MazeAction]:
 
    val sarsa = symsim.concrete.ConcreteExpectedSarsa (
      agent = Maze,

--- a/src/test/scala/symsim/examples/concrete/simplemaze/MazeSpec.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/MazeSpec.scala
@@ -16,30 +16,30 @@ object MazeSpec
 
   property ("Agent near to left wall, cannot go left") =
     forAll { (s: MazeState) =>
-      for (s1, r) <- Maze.step (1, s._2) (Left)
+      for (s1, r) <- Maze.step (1, s._2, s._3) (Left)
       yield s1._1 == 1
     }
 
   property ("Agent near to right wall, cannot go right") =
     forAll { (s: MazeState) =>
-      for (s1, r) <- Maze.step (4, s._2) (Right)
+      for (s1, r) <- Maze.step (4, s._2, s._3) (Right)
       yield s1._1 == 4
     }
 
   property ("Agent near to up wall, cannot go up") =
     forAll { (s: MazeState) =>
-      for (s1, r) <- Maze.step (s._1, 3) (Up)
+      for (s1, r) <- Maze.step (s._1, 3, s._3) (Up)
       yield s1._2 == 3
     }
 
   property ("Agent near to down wall, cannot go down") =
     forAll { (s: MazeState) =>
-      for (s1, r) <- Maze.step (s._1, 1) (Down)
+      for (s1, r) <- Maze.step (s._1, 1, s._3) (Down)
       yield s1._2 == 1
     }
 
   property ("Agent cannot go into block") =
     forAll { (s: MazeState, a: MazeAction) =>
       for (s1, r) <- Maze.step (s) (a)
-      yield s1 != (2, 2)
+      yield (s1._1, s._2) != (2, 2)
     }

--- a/src/test/scala/symsim/examples/concrete/simplemaze/SarsaExperiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/SarsaExperiments.scala
@@ -4,7 +4,7 @@ package examples.concrete.simplemaze
 import Maze.instances.given
 
 class SarsaExperiments
-   extends ExperimentSpec[MazeState, MazeState, MazeAction]:
+   extends ExperimentSpec[MazeState, MazeObservableState, MazeAction]:
 
    val sarsa = symsim.concrete.ConcreteSarsa (
      agent = Maze,
@@ -17,8 +17,8 @@ class SarsaExperiments
    s"SimpleMaze experiment with ${sarsa}" in {
 
      val policies = learnAndLog(sarsa)
-        .grouped (10)
-        .take (10)
+        .grouped (100)
+        .take (100)
         .flatMap { _.headOption }
         .toList
 
@@ -32,7 +32,7 @@ class SarsaExperiments
 
       // We leave 4,3 and 4,2 unconstrained (loosing and winning,
       // final states)
-      
+
       // Which of policy is optimal is a bit hard to
       // establish, and depends on the constants in the reward
       // function. We include several options to decrease flakiness of

--- a/src/test/scala/symsim/examples/concrete/simplemaze/SarsaExperiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/SarsaExperiments.scala
@@ -10,17 +10,17 @@ class SarsaExperiments
      agent = Maze,
      alpha = 0.1,
      gamma = 1,
-     epsilon = 0.05,
+     epsilon = 0.1,
      episodes = 60000,
    )
 
    s"SimpleMaze experiment with ${sarsa}" in {
 
      val policies = learnAndLog(sarsa)
-        .grouped (100)
-        .take (100)
-        .flatMap { _.headOption }
-        .toList
+//        .grouped (100)
+//        .take (100)
+//        .flatMap { _.headOption }
+//        .toList
 
      val policy = policies.head
 

--- a/src/test/scala/symsim/examples/concrete/simplemaze/SarsaExperiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/SarsaExperiments.scala
@@ -17,10 +17,10 @@ class SarsaExperiments
    s"SimpleMaze experiment with ${sarsa}" in {
 
      val policies = learnAndLog(sarsa)
-//        .grouped (100)
-//        .take (100)
-//        .flatMap { _.headOption }
-//        .toList
+        .grouped (100)
+        .take (100)
+        .flatMap { _.headOption }
+        .toList
 
      val policy = policies.head
 


### PR DESCRIPTION
Simple maze agent has now a limited time frame, which allows us to run both learning and evaluation for many episodes.
Agent will die (without obtaining bad reward) if times out. In this way, we do not need to be worried about the learning policy. because, we only cut the process not add anything to learning model.
This was my suggestion for adding time frame option to the learning process in general that if one wants to set a limitation of running episodes, they can do it without adding more components to the state (you disagree).