### PR TITLE
memory issue in evaluation

### DIFF
--- a/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
+++ b/src/main/scala/symsim/examples/concrete/simplemaze/Maze.scala
@@ -51,10 +51,10 @@ object Maze
     Agent[MazeState, MazeObservableState, MazeAction, MazeReward, Randomized],
     Episodic:
 
-  val TimeHorizon: Int = 2000
+  val TimeHorizon: Int = 200000
 
   def isFinal (s: MazeState): Boolean =
-    (s._1, s._2) == (4, 3) || (s._1, s._2) == (4, 2) || s._3 == TimeHorizon
+    (s._1, s._2) == (4, 3) || (s._1, s._2) == (4, 2) || s._3 >= TimeHorizon
 
   // Maze is discrete
   def observe (s: MazeState): MazeObservableState = (s._1, s._2)

--- a/src/test/scala/symsim/examples/concrete/simplemaze/SarsaExperiments.scala
+++ b/src/test/scala/symsim/examples/concrete/simplemaze/SarsaExperiments.scala
@@ -2,6 +2,7 @@ package symsim
 package examples.concrete.simplemaze
 
 import Maze.instances.given
+import symsim.concrete.Randomized
 
 class SarsaExperiments
    extends ExperimentSpec[MazeState, MazeObservableState, MazeAction]:
@@ -11,16 +12,16 @@ class SarsaExperiments
      alpha = 0.1,
      gamma = 1,
      epsilon0 = 0.1,
-     episodes = 60000,
+     episodes = 10000,
    )
 
    s"SimpleMaze experiment with ${sarsa}" in {
 
      val policies = learnAndLog(sarsa)
-        .grouped (100)
-        .take (100)
-        .flatMap { _.headOption }
-        .toList
+//        .grouped (100)
+//        .take (100)
+//        .flatMap { _.headOption }
+//        .toList
 
      val policy = policies.head
 
@@ -47,6 +48,7 @@ class SarsaExperiments
       // Left is faster, down is safer
       withClue ("4,1") { policy (4, 1) should (be (Down) or be (Left)) }
 
-      val results = eval (sarsa, policies)
+      val evalInitial = Randomized.const ((1, 1, 0))
+      val results = eval (sarsa, policies, Some (evalInitial))
       results.save ("simplemaze.csv")
    }


### PR DESCRIPTION
The simple maze trials are now longer which results in heap issues while evaluating. To see the results
`testOnly symsim.examples.concrete.simplemaze.SarsaExperiments`
If you did not see the heap issue, please try again. Because it is appearing when the learned policy has situation that timeout happens.