### PR TITLE
Eval: fix debugging noise committed by mistake

### DIFF
--- a/src/test/scala/symsim/ExperimentSpec.scala
+++ b/src/test/scala/symsim/ExperimentSpec.scala
@@ -67,7 +67,6 @@ trait ExperimentSpec[State, ObservableState, Action]
     noOfEpisodes: Int = 5
   ):  EvaluationResults = 
     val ss: Randomized[State] = initials.getOrElse (setup.agent.initialize)
-    println(policies.map {_.toString}.mkString("\n"))
     for p <- policies
         episodeRewards: Randomized[Randomized[Double]] = setup.evaluate (p, ss)
         rewards: Randomized[Double] = episodeRewards.map { e => e.sample () }


### PR DESCRIPTION
This debugging print seems to be merged by mistake.  Please check and merge.